### PR TITLE
Add Caddy service to docker-compose, refactor frontend Dockerfile for…

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,0 +1,15 @@
+{
+    # Global options
+    email your-email@example.com
+}
+
+paper-trader.net {
+    # Serve frontend files
+    reverse_proxy / frontend:80
+
+    # Proxy API requests to backend
+    handle /api/* {
+        reverse_proxy backend:8080
+    }
+}
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,25 @@
 version: '3.8'
 
 services:
+  caddy:
+    image: caddy:2
+    restart: always
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile
+      - caddy_data:/data
+      - caddy_config:/config
+    depends_on:
+      - frontend
+      - backend
+
   backend:
     build:
       context: ./backend
       dockerfile: Dockerfile
-    ports:
-      - "8080:8080"
+    restart: always
     environment:
       - PORT=8080
       - MONGODB_URI=${MONGODB_URI}
@@ -17,39 +30,18 @@ services:
     depends_on:
       mongodb:
         condition: service_healthy
-    develop:
-      watch:
-        - action: rebuild
-          path: ./backend
 
   frontend:
     build:
       context: ./frontend
       dockerfile: Dockerfile
-    ports:
-      - "3000:3000"
+    restart: always
     environment:
-      - REACT_APP_API_URL=http://localhost:8080
-    volumes:
-      - ./frontend/src:/app/src
-      - ./frontend/public:/app/public
-    stdin_open: true
-    tty: true
-    develop:
-      watch:
-        - action: sync
-          path: ./frontend/src
-          target: /app/src
-        - action: sync
-          path: ./frontend/public
-          target: /app/public
-        - action: rebuild
-          path: ./frontend/package.json
+      - REACT_APP_API_URL=${REACT_APP_API_URL}
 
   mongodb:
     image: mongo:latest
-    ports:
-      - "27017:27017"
+    restart: always
     volumes:
       - mongodb_data:/data/db
     healthcheck:
@@ -61,3 +53,5 @@ services:
 
 volumes:
   mongodb_data:
+  caddy_data:
+  caddy_config:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,13 +1,23 @@
-FROM node:18-alpine
+# Build stage
+FROM node:18-alpine AS build
 
 WORKDIR /app
 
 COPY package.json package-lock.json ./
-
 RUN npm install
 
 COPY . .
+RUN npm run build
 
-EXPOSE 3000
+# Production stage
+FROM nginx:alpine
 
-CMD ["npm", "start"]
+# Copy built files from build stage
+COPY --from=build /app/build /usr/share/nginx/html
+
+# Copy custom nginx config if needed (optional, but good for SPA routing)
+# COPY nginx.conf /etc/nginx/conf.d/default.conf
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,4 +1,4 @@
-const API_BASE = 'http://localhost:8080/api';
+const API_BASE = process.env.REACT_APP_API_URL || 'http://localhost:8080/api';
 
 export const apiRequest = async (endpoint, options = {}) => {
   const token = localStorage.getItem('token');


### PR DESCRIPTION
… multi-stage build, and update API base URL handling

- Introduced Caddy as a reverse proxy service in docker-compose.yml with necessary configurations.
- Refactored frontend Dockerfile to implement a multi-stage build, optimizing the image size and using Nginx for serving the application.
- Updated API base URL in frontend to utilize environment variable for better configuration management.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add Caddy reverse proxy and compose service, switch frontend to multi-stage Nginx build, and make API base URL configurable via env.
> 
> - **Infra / Reverse Proxy**:
>   - Add `Caddyfile` for `paper-trader.net`: proxies root to `frontend:80` and `handle /api/*` to `backend:8080`.
>   - Introduce `caddy` service in `docker-compose.yml` with ports `80/443`, config/data volumes, and deps on `frontend`/`backend`.
> - **Frontend Build/Deploy**:
>   - Refactor `frontend/Dockerfile` to multi-stage build; serve built assets via `nginx` (exposes `80`).
> - **Configuration**:
>   - `frontend/src/utils/api.js`: API base now derives from `REACT_APP_API_URL` with localhost fallback.
>   - `docker-compose.yml`: pass `REACT_APP_API_URL` to `frontend`.
> - **Compose Adjustments**:
>   - Remove direct port mappings from app services; add `restart: always`; add Caddy volumes; retain MongoDB healthcheck.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 171b1ae6f0b488c0b2c7ade0ea52b3b5ce2c63c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->