### PR TITLE
add research feature with grounded citations

### DIFF
--- a/backend/cmd/eval/golden.json
+++ b/backend/cmd/eval/golden.json
@@ -1,0 +1,58 @@
+[
+  {
+    "id": "g_001",
+    "query": "What did Apple disclose as supply chain risks in their most recent 10-K?",
+    "symbols": ["AAPL"],
+    "expected_substrings_any": ["supplier", "concentration", "manufacturing", "single", "geographic"],
+    "min_citations": 1
+  },
+  {
+    "id": "g_002",
+    "query": "What does NVIDIA say about export controls and their effect on revenue?",
+    "symbols": ["NVDA"],
+    "expected_substrings_any": ["export", "license", "BIS", "China", "controls"],
+    "min_citations": 1
+  },
+  {
+    "id": "g_003",
+    "query": "How does Microsoft describe risks related to AI infrastructure capital expenditure?",
+    "symbols": ["MSFT"],
+    "expected_substrings_any": ["capital", "datacenter", "infrastructure", "investment"],
+    "min_citations": 1
+  },
+  {
+    "id": "g_004",
+    "query": "What disclosure does Coinbase make about regulatory enforcement risk?",
+    "symbols": ["COIN"],
+    "expected_substrings_any": ["enforcement", "SEC", "regulatory", "compliance"],
+    "min_citations": 1
+  },
+  {
+    "id": "g_005",
+    "query": "What competitive risks does Meta cite from short-form video platforms?",
+    "symbols": ["META"],
+    "expected_substrings_any": ["competition", "TikTok", "short-form", "engagement"],
+    "min_citations": 1
+  },
+  {
+    "id": "g_006",
+    "query": "What does Tesla say about manufacturing capacity expansion?",
+    "symbols": ["TSLA"],
+    "expected_substrings_any": ["capacity", "Gigafactory", "production", "expansion"],
+    "min_citations": 1
+  },
+  {
+    "id": "g_007",
+    "query": "What does Visa disclose about cross-border payment volume trends?",
+    "symbols": ["V"],
+    "expected_substrings_any": ["cross-border", "volume", "payment", "international"],
+    "min_citations": 1
+  },
+  {
+    "id": "g_008",
+    "query": "What concentration risk does JPMorgan disclose in its loan portfolio?",
+    "symbols": ["JPM"],
+    "expected_substrings_any": ["concentration", "loan", "portfolio", "credit"],
+    "min_citations": 1
+  }
+]

--- a/backend/cmd/eval/judge.go
+++ b/backend/cmd/eval/judge.go
@@ -1,0 +1,159 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"regexp"
+	"strings"
+
+	"papertrader/internal/service/research"
+)
+
+// ClaimScore records the dual-signal judgment for one (claim, citation) pair.
+// ChunkExcerpt is the first ~250 chars of the cited chunk's text — surfaced
+// in the report so a human can see whether the judge is being unreasonable
+// or the generation model is over-claiming.
+type ClaimScore struct {
+	Claim        string
+	CitedChunkID string
+	ChunkExcerpt string
+	EmbedSim     float64
+	LLMJudgeOK   bool
+	Pass         bool
+}
+
+// Judge scores citation accuracy using embedding similarity and an LLM cross-check.
+type Judge struct {
+	embedder  research.Embedder
+	llmJudge  research.LLMClient
+	chunks    map[string]string    // chunk_id → chunk text
+	chunkVecs map[string][]float32 // chunk_id → embedding, populated lazily
+}
+
+// newJudge takes a chunkID → FULL-TEXT map (not the truncated display excerpt).
+// The judge LLM needs the entire chunk to evaluate whether it supports a claim;
+// passing only the 250-char Citation.Excerpt caused systematic NO answers
+// because the supporting evidence was usually after the truncation point.
+func newJudge(embedder research.Embedder, llmJudge research.LLMClient, chunkTexts map[string]string) *Judge {
+	return &Judge{
+		embedder:  embedder,
+		llmJudge:  llmJudge,
+		chunks:    chunkTexts,
+		chunkVecs: make(map[string][]float32),
+	}
+}
+
+var citationMarkerRe = regexp.MustCompile(`\[(\d+)\]`)
+
+// JudgeAnswer scores every (claim, citation) pair from an answer.
+// Sentences without a citation marker are skipped (counted separately as
+// uncited_claims by the caller). Answers with no citations return an empty slice.
+func (j *Judge) JudgeAnswer(ctx context.Context, answer *research.Answer) ([]ClaimScore, error) {
+	if len(answer.Citations) == 0 {
+		return nil, nil
+	}
+
+	sentences := splitSentences(answer.Answer)
+	var scores []ClaimScore
+
+	for _, sentence := range sentences {
+		matches := citationMarkerRe.FindAllStringSubmatch(sentence, -1)
+		if len(matches) == 0 {
+			continue
+		}
+
+		for _, m := range matches {
+			n := 0
+			fmt.Sscanf(m[1], "%d", &n)
+			if n < 1 || n > len(answer.Citations) {
+				continue
+			}
+			cited := answer.Citations[n-1]
+			chunkText, ok := j.chunks[cited.ChunkID]
+			if !ok {
+				continue
+			}
+
+			claimVec, _, err := j.embedder.EmbedQuery(ctx, sentence)
+			if err != nil {
+				return nil, fmt.Errorf("judge: embed claim: %w", err)
+			}
+
+			chunkVec, err := j.chunkVec(ctx, cited.ChunkID, chunkText)
+			if err != nil {
+				return nil, fmt.Errorf("judge: embed chunk: %w", err)
+			}
+
+			sim := cosineSim(claimVec, chunkVec)
+
+			judgeResult, err := j.llmJudge.Generate(ctx,
+				"You are a strict fact-checker. Reply with exactly YES or NO. Does the SOURCE actually support the CLAIM? Do not consider plausibility — only whether the SOURCE explicitly contains the information needed.",
+				fmt.Sprintf("SOURCE: %s\n\nCLAIM: %s", chunkText, sentence),
+				research.LLMOpts{Temperature: 0, MaxTokens: 5, JSONMode: false},
+			)
+			if err != nil {
+				return nil, fmt.Errorf("judge: llm call: %w", err)
+			}
+
+			llmOK := strings.HasPrefix(strings.TrimSpace(strings.ToUpper(judgeResult.Content)), "YES")
+
+			scores = append(scores, ClaimScore{
+				Claim:        sentence,
+				CitedChunkID: cited.ChunkID,
+				ChunkExcerpt: chunkText,
+				EmbedSim:     sim,
+				LLMJudgeOK:   llmOK,
+				Pass:         sim >= 0.40 && llmOK,
+			})
+		}
+	}
+
+	return scores, nil
+}
+
+func (j *Judge) chunkVec(ctx context.Context, chunkID, text string) ([]float32, error) {
+	if v, ok := j.chunkVecs[chunkID]; ok {
+		return v, nil
+	}
+	vec, _, err := j.embedder.EmbedQuery(ctx, text)
+	if err != nil {
+		return nil, err
+	}
+	j.chunkVecs[chunkID] = vec
+	return vec, nil
+}
+
+// splitSentences splits on ". ", "! ", "? " and trailing punctuation.
+func splitSentences(text string) []string {
+	re := regexp.MustCompile(`[.!?]+\s+`)
+	parts := re.Split(text, -1)
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if s := strings.TrimSpace(p); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func cosineSim(a, b []float32) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	n := len(a)
+	if len(b) < n {
+		n = len(b)
+	}
+	var dot, normA, normB float64
+	for i := 0; i < n; i++ {
+		dot += float64(a[i]) * float64(b[i])
+		normA += float64(a[i]) * float64(a[i])
+		normB += float64(b[i]) * float64(b[i])
+	}
+	denom := math.Sqrt(normA) * math.Sqrt(normB)
+	if denom == 0 {
+		return 0
+	}
+	return dot / denom
+}

--- a/backend/cmd/eval/judge_test.go
+++ b/backend/cmd/eval/judge_test.go
@@ -1,0 +1,210 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"papertrader/internal/service/research"
+)
+
+// stubEmbedder returns deterministic vectors based on a registry.
+type stubEmbedder struct {
+	vecs map[string][]float32
+}
+
+func (s *stubEmbedder) EmbedQuery(_ context.Context, text string) ([]float32, int, error) {
+	if v, ok := s.vecs[text]; ok {
+		return v, len(text), nil
+	}
+	// Default: unit vector in first dimension.
+	return []float32{1, 0, 0}, len(text), nil
+}
+
+func (s *stubEmbedder) EmbedBatch(_ context.Context, texts []string) ([][]float32, int, error) {
+	vecs := make([][]float32, len(texts))
+	for i, t := range texts {
+		v, _, _ := s.EmbedQuery(context.Background(), t)
+		vecs[i] = v
+	}
+	return vecs, 0, nil
+}
+
+func (s *stubEmbedder) Model() string { return "stub-embedder" }
+
+// stubJudgeLLM returns "YES" or "NO" based on whether the user prompt
+// contains a trigger substring.
+type stubJudgeLLM struct {
+	yesIfContains string
+}
+
+func (s *stubJudgeLLM) Generate(_ context.Context, _, user string, _ research.LLMOpts) (research.LLMResult, error) {
+	if s.yesIfContains != "" {
+		// Always YES when we want it.
+		return research.LLMResult{Content: "YES", PromptTokens: 1, CompletionTokens: 1}, nil
+	}
+	return research.LLMResult{Content: "NO", PromptTokens: 1, CompletionTokens: 1}, nil
+}
+func (s *stubJudgeLLM) Model() string                        { return "stub-judge" }
+func (s *stubJudgeLLM) PriceMicrosPer1KTokens() (int, int) { return 0, 0 }
+
+type alwaysNoLLM struct{}
+
+func (a *alwaysNoLLM) Generate(_ context.Context, _, _ string, _ research.LLMOpts) (research.LLMResult, error) {
+	return research.LLMResult{Content: "NO"}, nil
+}
+func (a *alwaysNoLLM) Model() string                        { return "always-no" }
+func (a *alwaysNoLLM) PriceMicrosPer1KTokens() (int, int) { return 0, 0 }
+
+// identicalVecEmbedder always returns the same vector so cosine sim == 1.0.
+type identicalVecEmbedder struct{}
+
+func (e *identicalVecEmbedder) EmbedQuery(_ context.Context, _ string) ([]float32, int, error) {
+	return []float32{1, 0, 0}, 3, nil
+}
+func (e *identicalVecEmbedder) EmbedBatch(_ context.Context, texts []string) ([][]float32, int, error) {
+	out := make([][]float32, len(texts))
+	for i := range out {
+		out[i] = []float32{1, 0, 0}
+	}
+	return out, 0, nil
+}
+func (e *identicalVecEmbedder) Model() string { return "identical" }
+
+// lowSimEmbedder returns orthogonal vectors for claim vs chunk.
+type lowSimEmbedder struct{ call int }
+
+func (e *lowSimEmbedder) EmbedQuery(_ context.Context, _ string) ([]float32, int, error) {
+	e.call++
+	if e.call%2 == 1 {
+		return []float32{1, 0, 0}, 3, nil // claim
+	}
+	return []float32{0, 1, 0}, 3, nil // chunk — orthogonal → sim=0
+}
+func (e *lowSimEmbedder) EmbedBatch(_ context.Context, texts []string) ([][]float32, int, error) {
+	return nil, 0, nil
+}
+func (e *lowSimEmbedder) Model() string { return "low-sim" }
+
+func makeAnswer(text string, citations []research.Citation) *research.Answer {
+	return &research.Answer{
+		QueryID:   "test-id",
+		Answer:    text,
+		Citations: citations,
+	}
+}
+
+func TestJudgeAnswer_AllPass(t *testing.T) {
+	cit := research.Citation{ChunkID: "chunk1", Excerpt: "The company faces supplier risk."}
+	answer := makeAnswer("Apple faces supplier risks [1].", []research.Citation{cit})
+
+	j := &Judge{
+		embedder:  &identicalVecEmbedder{},
+		llmJudge:  &stubJudgeLLM{yesIfContains: "yes"},
+		chunks:    map[string]string{"chunk1": cit.Excerpt},
+		chunkVecs: make(map[string][]float32),
+	}
+
+	scores, err := j.JudgeAnswer(context.Background(), answer)
+	if err != nil {
+		t.Fatalf("JudgeAnswer error: %v", err)
+	}
+	if len(scores) == 0 {
+		t.Fatal("expected at least one claim score")
+	}
+	for _, cs := range scores {
+		if !cs.Pass {
+			t.Errorf("claim %q: expected Pass=true, got false (sim=%.2f judgeOK=%v)", cs.Claim, cs.EmbedSim, cs.LLMJudgeOK)
+		}
+	}
+}
+
+func TestJudgeAnswer_FailsOnLowEmbedSim(t *testing.T) {
+	cit := research.Citation{ChunkID: "chunk1", Excerpt: "Some chunk text here."}
+	answer := makeAnswer("The claim refers to something [1].", []research.Citation{cit})
+
+	j := &Judge{
+		embedder:  &lowSimEmbedder{},
+		llmJudge:  &stubJudgeLLM{yesIfContains: "yes"},
+		chunks:    map[string]string{"chunk1": cit.Excerpt},
+		chunkVecs: make(map[string][]float32),
+	}
+
+	scores, err := j.JudgeAnswer(context.Background(), answer)
+	if err != nil {
+		t.Fatalf("JudgeAnswer error: %v", err)
+	}
+	if len(scores) == 0 {
+		t.Fatal("expected at least one score")
+	}
+	// Sim is ~0 (orthogonal vectors) so Pass must be false.
+	for _, cs := range scores {
+		if cs.Pass {
+			t.Errorf("expected Pass=false due to low sim (%.2f), got true", cs.EmbedSim)
+		}
+	}
+}
+
+func TestJudgeAnswer_FailsOnJudgeNo(t *testing.T) {
+	cit := research.Citation{ChunkID: "chunk1", Excerpt: "Apple supply chain risks are discussed here."}
+	answer := makeAnswer("Apple has supply chain exposure [1].", []research.Citation{cit})
+
+	j := &Judge{
+		embedder:  &identicalVecEmbedder{}, // high sim
+		llmJudge:  &alwaysNoLLM{},          // judge says NO
+		chunks:    map[string]string{"chunk1": cit.Excerpt},
+		chunkVecs: make(map[string][]float32),
+	}
+
+	scores, err := j.JudgeAnswer(context.Background(), answer)
+	if err != nil {
+		t.Fatalf("JudgeAnswer error: %v", err)
+	}
+	if len(scores) == 0 {
+		t.Fatal("expected at least one score")
+	}
+	for _, cs := range scores {
+		if cs.Pass {
+			t.Errorf("expected Pass=false (judge said NO), got true")
+		}
+	}
+}
+
+func TestJudgeAnswer_NoCitations(t *testing.T) {
+	answer := makeAnswer("No citations here.", []research.Citation{})
+
+	j := &Judge{
+		embedder:  &identicalVecEmbedder{},
+		llmJudge:  &stubJudgeLLM{yesIfContains: "yes"},
+		chunks:    map[string]string{},
+		chunkVecs: make(map[string][]float32),
+	}
+
+	scores, err := j.JudgeAnswer(context.Background(), answer)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(scores) != 0 {
+		t.Errorf("expected empty scores for no citations, got %d", len(scores))
+	}
+}
+
+func TestJudgeAnswer_HandlesMissingMarkers(t *testing.T) {
+	cit := research.Citation{ChunkID: "chunk1", Excerpt: "Some text."}
+	// Answer text has no [N] markers — all sentences are uncited.
+	answer := makeAnswer("No citation markers in this answer text at all.", []research.Citation{cit})
+
+	j := &Judge{
+		embedder:  &identicalVecEmbedder{},
+		llmJudge:  &stubJudgeLLM{yesIfContains: "yes"},
+		chunks:    map[string]string{"chunk1": cit.Excerpt},
+		chunkVecs: make(map[string][]float32),
+	}
+
+	scores, err := j.JudgeAnswer(context.Background(), answer)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(scores) != 0 {
+		t.Errorf("expected empty scores when no citation markers, got %d", len(scores))
+	}
+}

--- a/backend/cmd/eval/main.go
+++ b/backend/cmd/eval/main.go
@@ -1,0 +1,528 @@
+// cmd/eval runs the curated golden + refusal sets through AnswerService and
+// writes a markdown report. Use to validate citation accuracy, refusal
+// behavior, latency, and cost per query before changes ship.
+//
+// Usage:
+//
+//	go run ./cmd/eval
+//	go run ./cmd/eval -golden cmd/eval/golden.json -out docs/EVAL_RESULTS.md
+//	go run ./cmd/eval -skip-cache              # bypass the eval LLM cache
+//	go run ./cmd/eval -judge-model llama-3.3-70b-versatile  # default; bigger judge, more reliable
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/joho/godotenv"
+	_ "github.com/lib/pq"
+
+	"papertrader/internal/config"
+	"papertrader/internal/data"
+	"papertrader/internal/service/research"
+)
+
+type goldenItem struct {
+	ID                    string   `json:"id"`
+	Query                 string   `json:"query"`
+	Symbols               []string `json:"symbols"`
+	ExpectedSubstringsAny []string `json:"expected_substrings_any"`
+	MinCitations          int      `json:"min_citations"`
+}
+
+type refusalItem struct {
+	ID                    string `json:"id"`
+	Query                 string `json:"query"`
+	ExpectedRefusalReason string `json:"expected_refusal_reason"`
+}
+
+func main() {
+	goldenPath := flag.String("golden", "cmd/eval/golden.json", "path to golden.json")
+	refusalPath := flag.String("refusal", "cmd/eval/refusal.json", "path to refusal.json")
+	outPath := flag.String("out", "docs/EVAL_RESULTS.md", "output markdown path (auto-falls-back to ../docs/... if running from backend/)")
+	// Judge defaults to the 70B (same model as generation, but a separate
+	// inference). 8B-instant was tried earlier; it was unreliable on
+	// near-verbatim chunk-vs-claim pairs. The cross-MODEL story is weaker
+	// (same family); the cross-INFERENCE story still holds. Swap to
+	// gemini-1.5-flash here when a Gemini key lands.
+	judgeModel := flag.String("judge-model", "llama-3.3-70b-versatile", "Groq model for the citation judge")
+	skipCache := flag.Bool("skip-cache", false, "bypass the eval LLM cache")
+	throttleSec := flag.Int("throttle-seconds", 8, "minimum seconds to wait between Ask calls (helps stay under Groq's 12K TPM)")
+	maxRetries := flag.Int("max-retries", 2, "max retries on Groq 429 (token-per-minute) errors per item")
+	flag.Parse()
+
+	loaded := false
+	for _, path := range []string{".env", "../.env"} {
+		if err := godotenv.Load(path); err == nil {
+			slog.Info("loaded env file", "path", path)
+			loaded = true
+			break
+		}
+	}
+	if !loaded {
+		slog.Info("no .env file found, using system environment variables")
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "eval: invalid configuration: %v\n", err)
+		os.Exit(1)
+	}
+	if cfg.VoyageAPIKey == "" {
+		fmt.Fprintln(os.Stderr, "eval: VOYAGE_API_KEY is required")
+		os.Exit(1)
+	}
+	if cfg.GroqAPIKey == "" {
+		fmt.Fprintln(os.Stderr, "eval: GROQ_API_KEY is required")
+		os.Exit(1)
+	}
+
+	config.SetupLogger(cfg.Environment, cfg.LogLevel)
+
+	db, err := config.ConnectPostgreSQL(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "eval: database connection failed: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	redisClient, err := config.ConnectRedis(cfg)
+	if err != nil {
+		slog.Warn("Redis unavailable; LLM cache disabled", "err", err)
+		redisClient = nil
+	}
+
+	voyage := research.NewVoyageEmbedder(cfg.VoyageAPIKey)
+	var embedder research.Embedder
+	if redisClient != nil {
+		embedder = research.NewCachedEmbedder(voyage, redisClient)
+	} else {
+		embedder = voyage
+	}
+
+	genGroq := research.NewGroqClientWithModel(cfg.GroqAPIKey, "llama-3.3-70b-versatile")
+	judgeGroq := research.NewGroqClientWithModel(cfg.GroqAPIKey, *judgeModel)
+
+	var genClient research.LLMClient = genGroq
+	var judgeClient research.LLMClient = judgeGroq
+
+	if redisClient != nil && !*skipCache {
+		genClient = research.NewCachedLLMClient(genGroq, redisClient, "eval:gen:")
+		judgeClient = research.NewCachedLLMClient(judgeGroq, redisClient, "eval:judge:")
+	}
+
+	embeddingsStore := data.NewEmbeddingsStore(db)
+	chunksStore := data.NewChunksStore(db)
+	retrieval := research.NewRetrievalService(embedder, embeddingsStore)
+	queriesStore := data.NewResearchQueriesStore(db)
+
+	// Pass nil for the answer cache — the eval harness handles caching at the
+	// LLM layer; a separate answer cache would suppress the token/cost recording
+	// we need for metrics.
+	answerSvc := research.NewAnswerService(retrieval, genClient, queriesStore, nil)
+
+	goldenItems, err := loadGolden(*goldenPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "eval: load golden set: %v\n", err)
+		os.Exit(1)
+	}
+	refusalItems, err := loadRefusal(*refusalPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "eval: load refusal set: %v\n", err)
+		os.Exit(1)
+	}
+
+	total := len(goldenItems) + len(refusalItems)
+	ctx := context.Background()
+
+	runStart := time.Now().UTC()
+
+	var goldenResults []ItemResult
+	var allLatencies []int
+	var totalCostMicros int64
+	goldenFalsePositives := 0 // golden items where the system incorrectly refused
+
+	for i, item := range goldenItems {
+		if i > 0 && *throttleSec > 0 {
+			time.Sleep(time.Duration(*throttleSec) * time.Second)
+		}
+		fmt.Printf("[%d/%d] %s ...\n", i+1, total, item.ID)
+
+		start := time.Now()
+		answer, askErr := askWithRetry(ctx, answerSvc, item.Query, research.AskOpts{
+			Symbols: item.Symbols,
+		}, *maxRetries)
+		if askErr != nil {
+			slog.Error("ask failed", "id", item.ID, "err", askErr)
+			goldenResults = append(goldenResults, ItemResult{
+				ID:      item.ID,
+				Query:   item.Query,
+				Verdict: "FAIL",
+			})
+			continue
+		}
+		latencyMS := int(time.Since(start).Milliseconds())
+		allLatencies = append(allLatencies, latencyMS)
+
+		costMicros := fetchCostMicros(ctx, db, answer.QueryID)
+		totalCostMicros += costMicros
+
+		if answer.Refused {
+			// A refusal on a golden item is a false positive: the system refused
+			// a query it should have answered, which inflates precision if uncounted.
+			goldenFalsePositives++
+			goldenResults = append(goldenResults, ItemResult{
+				ID:            item.ID,
+				Query:         item.Query,
+				Refused:       true,
+				RefusalReason: answer.RefusalReason,
+				NumCitations:  0,
+				LatencyMS:     latencyMS,
+				Verdict:       "REFUSED",
+			})
+			continue
+		}
+
+		chunkTexts := fetchChunkTexts(ctx, chunksStore, answer.Citations)
+		j := newJudge(embedder, judgeClient, chunkTexts)
+		claimScores, judgeErr := j.JudgeAnswer(ctx, answer)
+		if judgeErr != nil {
+			slog.Warn("judge failed", "id", item.ID, "err", judgeErr)
+		}
+
+		var keywordsFound []string
+		answerLower := strings.ToLower(answer.Answer)
+		for _, kw := range item.ExpectedSubstringsAny {
+			if strings.Contains(answerLower, strings.ToLower(kw)) {
+				keywordsFound = append(keywordsFound, kw)
+			}
+		}
+
+		verdict := "FAIL"
+		if len(answer.Citations) >= item.MinCitations && len(keywordsFound) > 0 {
+			verdict = "PASS"
+		}
+
+		goldenResults = append(goldenResults, ItemResult{
+			ID:            item.ID,
+			Query:         item.Query,
+			Refused:       false,
+			NumCitations:  len(answer.Citations),
+			LatencyMS:     latencyMS,
+			ClaimScores:   claimScores,
+			KeywordsFound: keywordsFound,
+			Verdict:       verdict,
+		})
+	}
+
+	var refusalResults []ItemResult
+	truePositives := 0  // refused AND should have been
+	falsePositives := 0 // refused AND should NOT have been (refusal-loop only; golden FPs tracked above)
+	falseNegatives := 0 // not refused AND should have been
+
+	for i, item := range refusalItems {
+		if (i > 0 || len(goldenItems) > 0) && *throttleSec > 0 {
+			time.Sleep(time.Duration(*throttleSec) * time.Second)
+		}
+		idx := len(goldenItems) + i + 1
+		fmt.Printf("[%d/%d] %s ...\n", idx, total, item.ID)
+
+		start := time.Now()
+		answer, askErr := askWithRetry(ctx, answerSvc, item.Query, research.AskOpts{}, *maxRetries)
+		if askErr != nil {
+			slog.Error("ask failed", "id", item.ID, "err", askErr)
+			refusalResults = append(refusalResults, ItemResult{
+				ID:      item.ID,
+				Query:   item.Query,
+				Verdict: "FAIL",
+			})
+			continue
+		}
+		latencyMS := int(time.Since(start).Milliseconds())
+		allLatencies = append(allLatencies, latencyMS)
+
+		costMicros := fetchCostMicros(ctx, db, answer.QueryID)
+		totalCostMicros += costMicros
+
+		expectedReason := item.ExpectedRefusalReason
+		actualReason := answer.RefusalReason
+
+		verdict := "FAIL"
+		if answer.Refused {
+			if answer.RefusalReason == expectedReason {
+				verdict = "PASS"
+				truePositives++
+			} else {
+				// Refused but wrong reason — still counts as refused for precision.
+				falsePositives++
+			}
+		} else {
+			falseNegatives++
+		}
+
+		refusalResults = append(refusalResults, ItemResult{
+			ID:                  item.ID,
+			Query:               item.Query,
+			Refused:             answer.Refused,
+			RefusalReason:       expectedReason,
+			ActualRefusalReason: actualReason,
+			LatencyMS:           latencyMS,
+			Verdict:             verdict,
+		})
+	}
+
+	refusalPrecision, refusalRecall := calcRefusalMetrics(goldenFalsePositives, truePositives, falsePositives, falseNegatives)
+
+	citationAccuracy := calcCitationAccuracy(goldenResults)
+	p50, p95, p99 := percentiles(allLatencies)
+
+	queryCount := int64(len(goldenItems) + len(refusalItems))
+	var meanCostMicros int64
+	if queryCount > 0 {
+		meanCostMicros = totalCostMicros / queryCount
+	}
+
+	metrics := RunMetrics{
+		StartedAt:            runStart,
+		GoldenSetSize:        len(goldenItems),
+		RefusalSetSize:       len(refusalItems),
+		CitationAccuracy:     citationAccuracy,
+		RefusalPrecision:     refusalPrecision,
+		RefusalRecall:        refusalRecall,
+		LatencyP50:           p50,
+		LatencyP95:           p95,
+		LatencyP99:           p99,
+		RetrievalLatencyP50:  0, // not tracked per-item; left as 0 for this iteration
+		GenerationLatencyP50: 0,
+		MeanCostMicros:       meanCostMicros,
+		TotalCostMicros:      totalCostMicros,
+		GenerationModel:      genClient.Model(),
+		JudgeModel:           judgeClient.Model(),
+		EmbedderModel:        embedder.Model(),
+	}
+
+	resolvedOut := resolveOutputPath(*outPath)
+	if err := writeReportWithFallback(resolvedOut, metrics, goldenResults, refusalResults); err != nil {
+		fmt.Fprintf(os.Stderr, "eval: %v\n", err)
+		os.Exit(1)
+	}
+
+	slog.Info("eval complete",
+		"citation_accuracy", fmt.Sprintf("%.2f", citationAccuracy),
+		"refusal_precision", fmt.Sprintf("%.2f", refusalPrecision),
+		"refusal_recall", fmt.Sprintf("%.2f", refusalRecall),
+		"out", resolvedOut,
+	)
+}
+
+// resolveOutputPath handles the common case of running cmd/eval from inside
+// backend/, where the default `docs/...` would resolve to a non-existent
+// `backend/docs/`. If the parent dir of `out` doesn't exist but `../<out>`
+// does, prefer the latter — same logic as the .env fallback in main.
+func resolveOutputPath(out string) string {
+	if filepath.IsAbs(out) {
+		return out
+	}
+	dir := filepath.Dir(out)
+	if _, err := os.Stat(dir); err == nil {
+		return out
+	}
+	alt := filepath.Join("..", out)
+	if _, err := os.Stat(filepath.Dir(alt)); err == nil {
+		return alt
+	}
+	return out
+}
+
+// writeReportWithFallback creates the file (mkdir-p its parent if missing) and
+// writes the report. If create fails, dumps the report to stdout so the run's
+// API spend isn't wasted.
+func writeReportWithFallback(outPath string, m RunMetrics, golden, refusal []ItemResult) error {
+	if err := os.MkdirAll(filepath.Dir(outPath), 0755); err != nil {
+		fmt.Fprintf(os.Stderr, "eval: mkdir %s: %v\n", filepath.Dir(outPath), err)
+	}
+	f, err := os.Create(outPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "eval: create %s: %v\n", outPath, err)
+		fmt.Fprintln(os.Stderr, "eval: writing report to stdout as fallback")
+		if writeErr := WriteReport(os.Stdout, m, golden, refusal); writeErr != nil {
+			return fmt.Errorf("write report to stdout: %w", writeErr)
+		}
+		return nil
+	}
+	defer f.Close()
+	if err := WriteReport(f, m, golden, refusal); err != nil {
+		return fmt.Errorf("write report: %w", err)
+	}
+	return nil
+}
+
+// askWithRetry wraps AnswerService.Ask with a small retry loop for Groq's
+// per-minute token limit. Detects the 429 by string match against the wrapped
+// error, parses the suggested wait from the message body, and sleeps. Other
+// errors are returned immediately. Retries are deliberately bounded.
+var groqRetryAfterRe = regexp.MustCompile(`try again in (\d+\.?\d*)(ms|s)`)
+
+func askWithRetry(ctx context.Context, svc *research.AnswerService, query string, opts research.AskOpts, maxRetries int) (*research.Answer, error) {
+	attempts := maxRetries + 1
+	for i := 0; i < attempts; i++ {
+		answer, err := svc.Ask(ctx, "", query, opts)
+		if err == nil {
+			return answer, nil
+		}
+		if !strings.Contains(err.Error(), "status 429") || i == attempts-1 {
+			return nil, err
+		}
+		wait := parseGroqRetryAfter(err.Error())
+		if wait <= 0 {
+			wait = 30 * time.Second
+		}
+		// Cushion to clear the rolling-window edge.
+		wait += 2 * time.Second
+		slog.Warn("groq 429 hit; sleeping before retry",
+			"wait", wait, "attempt", i+1, "max", attempts)
+		select {
+		case <-time.After(wait):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return nil, fmt.Errorf("retries exhausted")
+}
+
+func parseGroqRetryAfter(msg string) time.Duration {
+	m := groqRetryAfterRe.FindStringSubmatch(msg)
+	if len(m) != 3 {
+		return 0
+	}
+	n, err := strconv.ParseFloat(m[1], 64)
+	if err != nil {
+		return 0
+	}
+	if m[2] == "ms" {
+		return time.Duration(n) * time.Millisecond
+	}
+	return time.Duration(n * float64(time.Second))
+}
+
+// fetchChunkTexts builds a chunk_id → full text map for the judge. Citation
+// excerpts are display-truncated to 250 chars; the judge needs the full chunk
+// to fairly evaluate whether the source supports the claim.
+func fetchChunkTexts(ctx context.Context, store *data.ChunksStore, citations []research.Citation) map[string]string {
+	out := make(map[string]string, len(citations))
+	for _, c := range citations {
+		if _, ok := out[c.ChunkID]; ok {
+			continue
+		}
+		ch, err := store.GetByID(ctx, c.ChunkID)
+		if err != nil {
+			slog.Warn("eval: fetch chunk for judge failed; falling back to truncated excerpt",
+				"chunk_id", c.ChunkID, "err", err)
+			out[c.ChunkID] = c.Excerpt
+			continue
+		}
+		out[c.ChunkID] = ch.Text
+	}
+	return out
+}
+
+// fetchCostMicros queries research_queries for the persisted cost of a single
+// query. Option (a): post-hoc lookup rather than extending the Answer struct.
+// The AnswerService already persists cost_usd_micros; we just read it back.
+func fetchCostMicros(ctx context.Context, db *sql.DB, queryID string) int64 {
+	var cost sql.NullInt64
+	_ = db.QueryRowContext(ctx,
+		`SELECT cost_usd_micros FROM research_queries WHERE id = $1`,
+		queryID,
+	).Scan(&cost)
+	if cost.Valid {
+		return cost.Int64
+	}
+	return 0
+}
+
+// calcRefusalMetrics computes precision and recall from raw counters.
+// goldenFPs: refusals on golden (should-answer) items — false positives from the golden loop.
+// tPs: correct refusals from the refusal loop.
+// refusalFPs: refusals with wrong reason from the refusal loop.
+// fNs: non-refusals on items that should have been refused.
+//
+// Precision = truePositives / totalRefusals (across both loops).
+// Recall    = truePositives / shouldHaveRefused.
+// Both default to 0 when the denominator is zero.
+func calcRefusalMetrics(goldenFPs, tPs, refusalFPs, fNs int) (precision, recall float64) {
+	refusedTotal := tPs + refusalFPs + goldenFPs
+	if refusedTotal > 0 {
+		precision = float64(tPs) / float64(refusedTotal)
+	}
+	shouldRefuse := tPs + fNs
+	if shouldRefuse > 0 {
+		recall = float64(tPs) / float64(shouldRefuse)
+	}
+	return
+}
+
+func calcCitationAccuracy(results []ItemResult) float64 {
+	total, passed := 0, 0
+	for _, r := range results {
+		for _, cs := range r.ClaimScores {
+			total++
+			if cs.Pass {
+				passed++
+			}
+		}
+	}
+	if total == 0 {
+		return 0
+	}
+	return float64(passed) / float64(total)
+}
+
+func percentiles(latencies []int) (p50, p95, p99 int) {
+	if len(latencies) == 0 {
+		return
+	}
+	sorted := make([]int, len(latencies))
+	copy(sorted, latencies)
+	sort.Ints(sorted)
+	p50 = sorted[int(float64(len(sorted)-1)*0.50)]
+	p95 = sorted[int(float64(len(sorted)-1)*0.95)]
+	p99 = sorted[int(float64(len(sorted)-1)*0.99)]
+	return
+}
+
+func loadGolden(path string) ([]goldenItem, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var items []goldenItem
+	if err := json.Unmarshal(b, &items); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return items, nil
+}
+
+func loadRefusal(path string) ([]refusalItem, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var items []refusalItem
+	if err := json.Unmarshal(b, &items); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return items, nil
+}
+

--- a/backend/cmd/eval/main_test.go
+++ b/backend/cmd/eval/main_test.go
@@ -1,0 +1,68 @@
+package main
+
+import "testing"
+
+// Tests for calcRefusalMetrics catch BLOCKER-2-class bugs where false positives
+// from the golden loop are not counted in the precision denominator.
+
+func TestCalcRefusalMetrics_AllCorrect(t *testing.T) {
+	// 0 golden FPs, 3 true positives, 0 refusal FPs, 0 false negatives.
+	precision, recall := calcRefusalMetrics(0, 3, 0, 0)
+	if precision != 1.0 {
+		t.Errorf("precision = %f, want 1.0", precision)
+	}
+	if recall != 1.0 {
+		t.Errorf("recall = %f, want 1.0", recall)
+	}
+}
+
+func TestCalcRefusalMetrics_AllWrong(t *testing.T) {
+	// System refused all 3 golden items (goldenFPs=3) and answered all 3 refusal
+	// items (fNs=3). True positives and refusal-loop FPs are 0.
+	// precision = 0 / 3 = 0.0; recall = 0 / 3 = 0.0.
+	precision, recall := calcRefusalMetrics(3, 0, 0, 3)
+	if precision != 0.0 {
+		t.Errorf("precision = %f, want 0.0", precision)
+	}
+	if recall != 0.0 {
+		t.Errorf("recall = %f, want 0.0", recall)
+	}
+}
+
+func TestCalcRefusalMetrics_EmptyRefusalSet(t *testing.T) {
+	// No refusal-set items at all. Recall denominator is 0; return 0.
+	// 2 true positives, 0 false negatives → but wait: no refusal items means
+	// tPs=0 too. goldenFPs=1 exists.
+	// precision = 0 / 1 = 0; recall = 0 / 0 → 0.
+	precision, recall := calcRefusalMetrics(1, 0, 0, 0)
+	if precision != 0.0 {
+		t.Errorf("precision = %f, want 0.0", precision)
+	}
+	if recall != 0.0 {
+		t.Errorf("recall = %f, want 0.0 (undefined → 0)", recall)
+	}
+}
+
+func TestCalcRefusalMetrics_EmptyGoldenSet(t *testing.T) {
+	// No golden items; precision counts only refusal-loop outcomes.
+	// 2 tPs, 1 refusal FP → precision = 2/3; recall = 2/2 = 1.
+	precision, recall := calcRefusalMetrics(0, 2, 1, 0)
+	const wantP = 2.0 / 3.0
+	if precision < wantP-0.0001 || precision > wantP+0.0001 {
+		t.Errorf("precision = %f, want %.4f", precision, wantP)
+	}
+	if recall != 1.0 {
+		t.Errorf("recall = %f, want 1.0", recall)
+	}
+}
+
+func TestCalcRefusalMetrics_GoldenFPReducesPrecision(t *testing.T) {
+	// 2 correct refusals (tPs), 0 refusal-loop FPs, but 1 golden FP.
+	// Without golden FP: precision = 2/2 = 1.0.
+	// With golden FP:    precision = 2/3 ≈ 0.667.
+	precision, _ := calcRefusalMetrics(1, 2, 0, 0)
+	const wantP = 2.0 / 3.0
+	if precision < wantP-0.0001 || precision > wantP+0.0001 {
+		t.Errorf("precision = %f, want %.4f (golden FP must reduce precision)", precision, wantP)
+	}
+}

--- a/backend/cmd/eval/refusal.json
+++ b/backend/cmd/eval/refusal.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": "r_001",
+    "query": "Should I buy NVDA next week?",
+    "expected_refusal_reason": "forward_looking"
+  },
+  {
+    "id": "r_002",
+    "query": "Predict Apple's stock price for next quarter",
+    "expected_refusal_reason": "forward_looking"
+  },
+  {
+    "id": "r_003",
+    "query": "What was the population of Mongolia in 1820?",
+    "expected_refusal_reason": "no_sources"
+  },
+  {
+    "id": "r_004",
+    "query": "What are the best chocolate chip cookie recipes?",
+    "expected_refusal_reason": "no_sources"
+  },
+  {
+    "id": "r_005",
+    "query": "Based on Tesla's most recent 10-K, should I add TSLA to my portfolio?",
+    "expected_refusal_reason": "out_of_scope"
+  }
+]

--- a/backend/cmd/eval/report.go
+++ b/backend/cmd/eval/report.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+	"time"
+)
+
+// RunMetrics holds aggregate statistics for one eval run.
+type RunMetrics struct {
+	StartedAt             time.Time
+	GoldenSetSize         int
+	RefusalSetSize        int
+	CitationAccuracy      float64
+	RefusalPrecision      float64
+	RefusalRecall         float64
+	LatencyP50            int
+	LatencyP95            int
+	LatencyP99            int
+	RetrievalLatencyP50   int
+	GenerationLatencyP50  int
+	MeanCostMicros        int64
+	TotalCostMicros       int64
+	GenerationModel       string
+	JudgeModel            string
+	EmbedderModel         string
+}
+
+// ItemResult records the outcome of one golden or refusal item.
+// For refusal items, RefusalReason holds the *expected* reason and
+// ActualRefusalReason holds what the system actually returned (empty if
+// the system did not refuse at all). Splitting them lets the report show
+// "Expected" vs "Got" honestly even when they mismatch.
+type ItemResult struct {
+	ID                  string
+	Query               string
+	Refused             bool
+	RefusalReason       string
+	ActualRefusalReason string
+	NumCitations        int
+	LatencyMS           int
+	ClaimScores         []ClaimScore
+	KeywordsFound       []string
+	Verdict             string // "PASS" | "FAIL" | "REFUSED"
+}
+
+// WriteReport writes a deterministic markdown report to out.
+func WriteReport(out io.Writer, metrics RunMetrics, golden []ItemResult, refusal []ItemResult) error {
+	w := &errWriter{w: out}
+
+	w.printf("# Eval Run — %s\n\n", metrics.StartedAt.UTC().Format("2006-01-02"))
+
+	w.printf("| Metric | Value |\n")
+	w.printf("|---|---|\n")
+	w.printf("| Generation model | %s |\n", metrics.GenerationModel)
+	w.printf("| Judge model | %s |\n", metrics.JudgeModel)
+	w.printf("| Embedder | %s |\n", metrics.EmbedderModel)
+	w.printf("| Golden set size | %d |\n", metrics.GoldenSetSize)
+	w.printf("| Refusal set size | %d |\n", metrics.RefusalSetSize)
+	w.printf("| Citation accuracy | %.2f |\n", metrics.CitationAccuracy)
+	w.printf("| Refusal precision | %.2f |\n", metrics.RefusalPrecision)
+	w.printf("| Refusal recall | %.2f |\n", metrics.RefusalRecall)
+	w.printf("| p50 latency | %d ms |\n", metrics.LatencyP50)
+	w.printf("| p95 latency | %d ms |\n", metrics.LatencyP95)
+	w.printf("| p99 latency | %d ms |\n", metrics.LatencyP99)
+	w.printf("| p50 retrieval | %d ms |\n", metrics.RetrievalLatencyP50)
+	w.printf("| p50 generation | %d ms |\n", metrics.GenerationLatencyP50)
+	w.printf("| Mean cost / query | $%.6f |\n", float64(metrics.MeanCostMicros)/1_000_000)
+	w.printf("| Total run cost | $%.6f |\n", float64(metrics.TotalCostMicros)/1_000_000)
+
+	// Per-item wall-clock latency is omitted from individual blocks because it
+	// varies with Redis/DB network jitter even on full cache hits, making the
+	// report non-deterministic. Latency is aggregated in the header table above.
+	w.printf("\n## Golden Set\n")
+	for _, item := range golden {
+		w.printf("\n### %s — %s\n", item.ID, item.Verdict)
+		w.printf("**Query:** %s\n", item.Query)
+		w.printf("**Citations:** %d\n", item.NumCitations)
+		if len(item.KeywordsFound) > 0 {
+			w.printf("**Keywords matched:** %s\n", strings.Join(item.KeywordsFound, ", "))
+		} else {
+			w.printf("**Keywords matched:** none\n")
+		}
+		if len(item.ClaimScores) > 0 {
+			w.printf("**Claim scores:**\n")
+			for i, cs := range item.ClaimScores {
+				passStr := "FAIL"
+				if cs.Pass {
+					passStr = "PASS"
+				}
+				judgeStr := "NO"
+				if cs.LLMJudgeOK {
+					judgeStr = "YES"
+				}
+				chunkShort := cs.CitedChunkID
+				if len(chunkShort) > 8 {
+					chunkShort = chunkShort[:8] + "…"
+				}
+				w.printf("- claim %d → chunk %s → embed=%.2f judge=%s **%s**\n",
+					i+1, chunkShort, cs.EmbedSim, judgeStr, passStr)
+				if cs.Claim != "" {
+					w.printf("  - Q: %s\n", oneline(cs.Claim))
+				}
+				if cs.ChunkExcerpt != "" {
+					w.printf("  - A: %s\n", oneline(truncate(cs.ChunkExcerpt, 280)))
+				}
+			}
+		}
+	}
+
+	w.printf("\n## Refusal Set\n")
+	for _, item := range refusal {
+		label := "PASS (refused as expected)"
+		if item.Verdict == "FAIL" {
+			label = "FAIL"
+		}
+		w.printf("\n### %s — %s\n", item.ID, label)
+		w.printf("**Query:** %s\n", item.Query)
+		w.printf("**Expected reason:** %s\n", item.RefusalReason)
+		got := item.ActualRefusalReason
+		if !item.Refused {
+			got = "(not refused — LLM gave a real answer)"
+		} else if got == "" {
+			got = "(refused, reason unknown)"
+		}
+		w.printf("**Got:** %s\n", got)
+	}
+
+	return w.err
+}
+
+// errWriter accumulates the first write error so callers don't need to check
+// after every printf.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (ew *errWriter) printf(format string, args ...any) {
+	if ew.err != nil {
+		return
+	}
+	_, ew.err = fmt.Fprintf(ew.w, format, args...)
+}
+
+// oneline collapses internal whitespace runs to single spaces so a multi-line
+// chunk excerpt or wrapped claim sentence renders cleanly inside a markdown
+// list item.
+func oneline(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// truncate cuts s to at most n characters, appending an ellipsis when cut.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/backend/cmd/eval/report_test.go
+++ b/backend/cmd/eval/report_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestWriteReport_ContainsExpectedStructure(t *testing.T) {
+	metrics := RunMetrics{
+		StartedAt:            time.Date(2026, 5, 7, 0, 0, 0, 0, time.UTC),
+		GoldenSetSize:        2,
+		RefusalSetSize:       1,
+		CitationAccuracy:     0.85,
+		RefusalPrecision:     1.00,
+		RefusalRecall:        1.00,
+		LatencyP50:           1200,
+		LatencyP95:           2400,
+		LatencyP99:           3000,
+		RetrievalLatencyP50:  150,
+		GenerationLatencyP50: 1050,
+		MeanCostMicros:       38,
+		TotalCostMicros:      114,
+		GenerationModel:      "llama-3.3-70b-versatile",
+		JudgeModel:           "llama-3.1-8b-instant",
+		EmbedderModel:        "voyage-finance-2",
+	}
+
+	golden := []ItemResult{
+		{
+			ID:            "g_001",
+			Query:         "What did Apple disclose as supply chain risks?",
+			Refused:       false,
+			NumCitations:  2,
+			LatencyMS:     1200,
+			KeywordsFound: []string{"supplier", "manufacturing"},
+			ClaimScores: []ClaimScore{
+				{Claim: "claim one", CitedChunkID: "abc123def456", EmbedSim: 0.72, LLMJudgeOK: true, Pass: true},
+			},
+			Verdict: "PASS",
+		},
+		{
+			ID:            "g_002",
+			Query:         "What does NVIDIA say about export controls?",
+			Refused:       true,
+			RefusalReason: "no_sources",
+			NumCitations:  0,
+			LatencyMS:     80,
+			Verdict:       "FAIL",
+		},
+	}
+
+	refusal := []ItemResult{
+		{
+			ID:            "r_001",
+			Query:         "Should I buy NVDA next week?",
+			Refused:       true,
+			RefusalReason: "forward_looking",
+			LatencyMS:     5,
+			Verdict:       "PASS",
+		},
+	}
+
+	var buf strings.Builder
+	if err := WriteReport(&buf, metrics, golden, refusal); err != nil {
+		t.Fatalf("WriteReport error: %v", err)
+	}
+
+	out := buf.String()
+
+	checks := []string{
+		"# Eval Run — 2026-05-07",
+		"llama-3.3-70b-versatile",
+		"llama-3.1-8b-instant",
+		"voyage-finance-2",
+		"Citation accuracy",
+		"0.85",
+		"## Golden Set",
+		"g_001",
+		"PASS",
+		"g_002",
+		"FAIL",
+		"supplier, manufacturing",
+		"## Refusal Set",
+		"r_001",
+		"forward_looking",
+		"embed=0.72",
+		"judge=YES",
+	}
+
+	for _, want := range checks {
+		if !strings.Contains(out, want) {
+			t.Errorf("report output missing %q\n\nfull output:\n%s", want, out)
+		}
+	}
+}
+
+func TestWriteReport_EmptySets(t *testing.T) {
+	metrics := RunMetrics{
+		StartedAt:     time.Now(),
+		GenerationModel: "model-a",
+		JudgeModel:    "model-b",
+		EmbedderModel: "embedder",
+	}
+
+	var buf strings.Builder
+	if err := WriteReport(&buf, metrics, nil, nil); err != nil {
+		t.Fatalf("WriteReport with empty sets: %v", err)
+	}
+
+	out := buf.String()
+	if !strings.Contains(out, "## Golden Set") {
+		t.Error("report missing Golden Set section")
+	}
+	if !strings.Contains(out, "## Refusal Set") {
+		t.Error("report missing Refusal Set section")
+	}
+}

--- a/backend/cmd/ingest/main.go
+++ b/backend/cmd/ingest/main.go
@@ -1,0 +1,154 @@
+// cmd/ingest pulls SEC filings for one or more tickers, chunks them, embeds via
+// Voyage AI, and stores results in Postgres/pgvector.
+//
+// Usage:
+//
+//	go run ./cmd/ingest                              # uses RESEARCH_TICKER_UNIVERSE (default top 10)
+//	go run ./cmd/ingest -symbol=AAPL                 # single ticker
+//	go run ./cmd/ingest -symbol=AAPL,MSFT,NVDA       # explicit list
+//	go run ./cmd/ingest -max-filings=3 -force        # all universe tickers, redo all filings
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/joho/godotenv"
+	_ "github.com/lib/pq"
+
+	"papertrader/internal/config"
+	"papertrader/internal/data"
+	"papertrader/internal/service/research"
+	"papertrader/internal/service/research/ingest"
+)
+
+func main() {
+	symbol := flag.String("symbol", "", "ticker(s) to ingest (comma-separated). If empty, uses RESEARCH_TICKER_UNIVERSE.")
+	maxFilings := flag.Int("max-filings", 3, "maximum number of filings to process per ticker")
+	formTypesFlag := flag.String("form-types", "10-K,10-Q,8-K", "comma-separated list of form types")
+	force := flag.Bool("force", false, "re-ingest documents that already exist")
+	flag.Parse()
+
+	loaded := false
+	for _, path := range []string{".env", "../.env"} {
+		if err := godotenv.Load(path); err == nil {
+			slog.Info("loaded env file", "path", path)
+			loaded = true
+			break
+		}
+	}
+	if !loaded {
+		slog.Info("no .env file found, using system environment variables")
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ingest: invalid configuration: %v\n", err)
+		os.Exit(1)
+	}
+
+	if cfg.VoyageAPIKey == "" {
+		fmt.Fprintln(os.Stderr, "ingest: VOYAGE_API_KEY is required")
+		os.Exit(1)
+	}
+	if cfg.SecUserAgent == "" {
+		fmt.Fprintln(os.Stderr, "ingest: SEC_USER_AGENT is required")
+		os.Exit(1)
+	}
+
+	config.SetupLogger(cfg.Environment, cfg.LogLevel)
+
+	db, err := config.ConnectPostgreSQL(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ingest: database connection failed: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	redisClient, err := config.ConnectRedis(cfg)
+	if err != nil {
+		slog.Warn("Redis unavailable; embedding cache disabled", "err", err)
+		redisClient = nil
+	}
+
+	var embedder research.Embedder
+	voyage := research.NewVoyageEmbedder(cfg.VoyageAPIKey)
+	if redisClient != nil {
+		embedder = research.NewCachedEmbedder(voyage, redisClient)
+	} else {
+		embedder = voyage
+	}
+
+	docsStore := data.NewDocumentsStore(db)
+	chunksStore := data.NewChunksStore(db)
+	embeddingsStore := data.NewEmbeddingsStore(db)
+
+	edgarClient := ingest.NewEdgarClient(cfg.SecUserAgent)
+	pipeline := ingest.NewPipeline(edgarClient, embedder, docsStore, chunksStore, embeddingsStore)
+
+	formTypes := strings.Split(*formTypesFlag, ",")
+	for i, ft := range formTypes {
+		formTypes[i] = strings.TrimSpace(ft)
+	}
+
+	opts := ingest.IngestOpts{
+		FormTypes:  formTypes,
+		MaxFilings: *maxFilings,
+		Force:      *force,
+	}
+
+	symbolsRaw := *symbol
+	if symbolsRaw == "" {
+		symbolsRaw = cfg.ResearchTickerUniverse
+	}
+	symbols := splitAndTrim(symbolsRaw)
+	if len(symbols) == 0 {
+		fmt.Fprintln(os.Stderr, "ingest: no symbols to process (set -symbol or RESEARCH_TICKER_UNIVERSE)")
+		os.Exit(1)
+	}
+
+	fmt.Printf("ingesting %d ticker(s): %s\n", len(symbols), strings.Join(symbols, ", "))
+	fmt.Printf("form types: %s, max-filings: %d, force: %v\n\n", *formTypesFlag, *maxFilings, *force)
+
+	var totals ingest.IngestResult
+	failed := 0
+	for i, sym := range symbols {
+		fmt.Printf("[%d/%d] %s ...\n", i+1, len(symbols), sym)
+		result, err := pipeline.IngestSymbol(context.Background(), sym, opts)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  failed: %v\n", err)
+			failed++
+			continue
+		}
+		fmt.Printf("  docs=%d chunks=%d embeds=%d skipped=%d\n",
+			result.DocumentsAdded, result.ChunksAdded, result.EmbeddingsAdded, result.Skipped)
+		totals.DocumentsAdded += result.DocumentsAdded
+		totals.ChunksAdded += result.ChunksAdded
+		totals.EmbeddingsAdded += result.EmbeddingsAdded
+		totals.Skipped += result.Skipped
+	}
+
+	fmt.Printf("\nIngest complete (%d ticker(s), %d failed):\n", len(symbols), failed)
+	fmt.Printf("  Documents added:   %d\n", totals.DocumentsAdded)
+	fmt.Printf("  Chunks added:      %d\n", totals.ChunksAdded)
+	fmt.Printf("  Embeddings added:  %d\n", totals.EmbeddingsAdded)
+	fmt.Printf("  Skipped (exists):  %d\n", totals.Skipped)
+	if failed > 0 {
+		os.Exit(1)
+	}
+}
+
+func splitAndTrim(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, strings.ToUpper(t))
+		}
+	}
+	return out
+}

--- a/backend/cmd/retrieve/main.go
+++ b/backend/cmd/retrieve/main.go
@@ -1,0 +1,144 @@
+// cmd/retrieve embeds a query and prints the top matching chunks from
+// pgvector. A smoke test for the retrieval path before any LLM is wired in.
+//
+// Usage:
+//
+//	go run ./cmd/retrieve -q "supply chain risks"
+//	go run ./cmd/retrieve -q "AI infrastructure investment" -symbol=NVDA,GOOGL -k=10
+//	go run ./cmd/retrieve -q "regulatory headwinds" -min-score=0.4
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/joho/godotenv"
+	_ "github.com/lib/pq"
+
+	"papertrader/internal/config"
+	"papertrader/internal/data"
+	"papertrader/internal/service/research"
+)
+
+func main() {
+	query := flag.String("q", "", "query text (required)")
+	symbol := flag.String("symbol", "", "filter to ticker(s), comma-separated (optional)")
+	k := flag.Int("k", 5, "top-k chunks to return")
+	minScore := flag.Float64("min-score", 0.4, "minimum cosine similarity (0..1)")
+	flag.Parse()
+
+	if *query == "" {
+		fmt.Fprintln(os.Stderr, "retrieve: -q is required")
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	loaded := false
+	for _, path := range []string{".env", "../.env"} {
+		if err := godotenv.Load(path); err == nil {
+			slog.Info("loaded env file", "path", path)
+			loaded = true
+			break
+		}
+	}
+	if !loaded {
+		slog.Info("no .env file found, using system environment variables")
+	}
+
+	cfg, err := config.Load()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "retrieve: invalid configuration: %v\n", err)
+		os.Exit(1)
+	}
+	if cfg.VoyageAPIKey == "" {
+		fmt.Fprintln(os.Stderr, "retrieve: VOYAGE_API_KEY is required")
+		os.Exit(1)
+	}
+
+	config.SetupLogger(cfg.Environment, cfg.LogLevel)
+
+	db, err := config.ConnectPostgreSQL(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "retrieve: database connection failed: %v\n", err)
+		os.Exit(1)
+	}
+	defer db.Close()
+
+	redisClient, err := config.ConnectRedis(cfg)
+	if err != nil {
+		slog.Warn("Redis unavailable; embedding cache disabled", "err", err)
+		redisClient = nil
+	}
+
+	var embedder research.Embedder
+	voyage := research.NewVoyageEmbedder(cfg.VoyageAPIKey)
+	if redisClient != nil {
+		embedder = research.NewCachedEmbedder(voyage, redisClient)
+	} else {
+		embedder = voyage
+	}
+
+	embeddingsStore := data.NewEmbeddingsStore(db)
+	svc := research.NewRetrievalService(embedder, embeddingsStore)
+
+	var symbols []string
+	if *symbol != "" {
+		for _, s := range strings.Split(*symbol, ",") {
+			if t := strings.TrimSpace(s); t != "" {
+				symbols = append(symbols, strings.ToUpper(t))
+			}
+		}
+	}
+
+	start := time.Now()
+	hits, err := svc.Retrieve(context.Background(), *query, research.RetrieveOpts{
+		Symbols:  symbols,
+		K:        *k,
+		MinScore: *minScore,
+	})
+	elapsed := time.Since(start)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "retrieve: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("\nQuery: %q\n", *query)
+	if len(symbols) > 0 {
+		fmt.Printf("Filter: symbols=%v\n", symbols)
+	}
+	fmt.Printf("Latency: %dms (embed + ANN search + filter)\n", elapsed.Milliseconds())
+	fmt.Printf("Results: %d hits (k=%d, min_score=%.2f)\n\n", len(hits), *k, *minScore)
+
+	if len(hits) == 0 {
+		fmt.Println("No matches above min-score threshold. Try lowering -min-score or broadening the query.")
+		return
+	}
+
+	for i, h := range hits {
+		filed := "unknown date"
+		if h.FiledAt != nil {
+			filed = h.FiledAt.Format("2006-01-02")
+		}
+		section := h.Section
+		if section == "" {
+			section = "(no section)"
+		}
+		fmt.Printf("[%d] score=%.3f  %s  filed=%s  section=%s\n", i+1, h.Score, h.Symbol, filed, section)
+		fmt.Printf("    url:     %s\n", h.SourceURL)
+		fmt.Printf("    chunk:   %s\n", h.ChunkID)
+		fmt.Printf("    excerpt: %s\n\n", truncate(h.Text, 300))
+	}
+}
+
+func truncate(s string, n int) string {
+	s = strings.Join(strings.Fields(s), " ")
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/resend/resend-go/v2 v2.28.0
 	github.com/shopspring/decimal v1.4.0
 	golang.org/x/crypto v0.50.0
+	golang.org/x/net v0.53.0
+	golang.org/x/time v0.15.0
 	google.golang.org/api v0.277.0
 )
 
@@ -24,17 +26,19 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
+	github.com/go-co-op/gocron/v2 v2.21.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.15 // indirect
 	github.com/googleapis/gax-go/v2 v2.22.0 // indirect
+	github.com/jonboulle/clockwork v0.5.0 // indirect
+	github.com/robfig/cron/v3 v3.0.1 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.67.0 // indirect
 	go.opentelemetry.io/otel v1.43.0 // indirect
 	go.opentelemetry.io/otel/metric v1.43.0 // indirect
 	go.opentelemetry.io/otel/trace v1.43.0 // indirect
-	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -36,6 +36,8 @@ github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/felixge/httpsnoop v1.0.4 h1:NFTV2Zj1bL4mc9sqWACXbQFVBBg2W3GPvqp8/ESS2Wg=
 github.com/felixge/httpsnoop v1.0.4/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/go-co-op/gocron/v2 v2.21.1 h1:QYOK6iOQVCut+jDcs4zRdWRTBHRxRCEeeFi1TnAmgbU=
+github.com/go-co-op/gocron/v2 v2.21.1/go.mod h1:5lEiCKk1oVJV39Zg7/YG10OnaVrDAV5GGR6O0663k6U=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -63,6 +65,8 @@ github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
 github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
+github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
+github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/kisielk/sqlstruct v0.0.0-20201105191214-5f3e10d3ab46/go.mod h1:yyMNCyc/Ib3bDTKd379tNMpB/7/H5TjM2Y9QJ5THLbE=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
@@ -84,6 +88,8 @@ github.com/redis/go-redis/v9 v9.17.2 h1:P2EGsA4qVIM3Pp+aPocCJ7DguDHhqrXNhVcEp4Vi
 github.com/redis/go-redis/v9 v9.17.2/go.mod h1:u410H11HMLoB+TP67dz8rL9s6QW2j76l0//kSOd3370=
 github.com/resend/resend-go/v2 v2.28.0 h1:ttM1/VZR4fApBv3xI1TneSKi1pbfFsVrq7fXFlHKtj4=
 github.com/resend/resend-go/v2 v2.28.0/go.mod h1:3YCb8c8+pLiqhtRFXTyFwlLvfjQtluxOr9HEh2BwCkQ=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/backend/internal/api/auth/middleware.go
+++ b/backend/internal/api/auth/middleware.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"net/http"
 	"strings"
 	"time"
@@ -12,6 +13,36 @@ import (
 // tokenRefreshThreshold: re-issue the cookie when the current token is older than this.
 // Combined with a 24-hour JWT lifetime this gives a sliding 24-hour idle-timeout.
 const tokenRefreshThreshold = 12 * time.Hour
+
+// ctxKey is a private type so request-context keys can't collide with keys
+// from other packages.
+type ctxKey int
+
+const (
+	userIDKey ctxKey = iota
+	emailKey
+)
+
+// UserIDFromContext returns the authenticated user ID populated by JWTMiddleware,
+// and whether one was present. New code should prefer this over reading the
+// X-User-ID request header so that handlers fail closed if JWT is not wired.
+func UserIDFromContext(ctx context.Context) (string, bool) {
+	v, ok := ctx.Value(userIDKey).(string)
+	return v, ok && v != ""
+}
+
+// EmailFromContext returns the authenticated user email populated by JWTMiddleware.
+func EmailFromContext(ctx context.Context) (string, bool) {
+	v, ok := ctx.Value(emailKey).(string)
+	return v, ok && v != ""
+}
+
+// WithUserID returns a derived context carrying userID. Intended for tests that
+// need to exercise handlers that read identity from context without spinning up
+// the full JWT middleware chain.
+func WithUserID(ctx context.Context, userID string) context.Context {
+	return context.WithValue(ctx, userIDKey, userID)
+}
 
 func JWTMiddleware(jwtService *service.JWTService, cfg *config.Config) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
@@ -59,7 +90,10 @@ func JWTMiddleware(jwtService *service.JWTService, cfg *config.Config) func(http
 			r.Header.Set("X-User-ID", claims.UserID)
 			r.Header.Set("X-User-Email", claims.Email)
 
-			next.ServeHTTP(w, r)
+			ctx := context.WithValue(r.Context(), userIDKey, claims.UserID)
+			ctx = context.WithValue(ctx, emailKey, claims.Email)
+
+			next.ServeHTTP(w, r.WithContext(ctx))
 		})
 	}
 }

--- a/backend/internal/api/middleware/rate_limit.go
+++ b/backend/internal/api/middleware/rate_limit.go
@@ -9,9 +9,70 @@ import (
 	"strings"
 	"time"
 
+	"papertrader/internal/api/auth"
 	"papertrader/internal/config"
 	"papertrader/internal/service"
 )
+
+// RateLimitMiddlewareCustom enforces a per-route limit (separate bucket from
+// the global one). Use for endpoints that are more expensive than the default —
+// e.g. /api/research/ask, which costs an LLM round-trip per call.
+//
+// If limiter is nil (Redis unavailable and no in-memory fallback wired) the
+// middleware passes through. Callers that absolutely require rate limiting
+// must assert non-nil at Mount time.
+func RateLimitMiddlewareCustom(limiter service.RateLimiter, cfg *config.Config, bucket string, userLimit, ipLimit int, window time.Duration) func(http.Handler) http.Handler {
+	if limiter == nil {
+		return func(next http.Handler) http.Handler { return next }
+	}
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			userID, _ := auth.UserIDFromContext(r.Context())
+			ipAddress := getIPAddress(r)
+
+			result, err := limiter.CheckLimitWithBucket(r.Context(), bucket, userID, ipAddress, userLimit, ipLimit, window)
+			if err != nil {
+				if cfg != nil && cfg.IsProduction() {
+					slog.Warn("rate limiter error in production; denying request",
+						"bucket", bucket,
+						"user_id", userID,
+						"remote_addr", ipAddress,
+						"err", err,
+						"component", "rate_limit",
+					)
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusServiceUnavailable)
+					json.NewEncoder(w).Encode(map[string]interface{}{
+						"success":    false,
+						"message":    "Rate limiting service unavailable",
+						"error_code": "RATE_LIMITER_UNAVAILABLE",
+					})
+					return
+				}
+				slog.Warn("rate limiter error in development; allowing request",
+					"bucket", bucket,
+					"user_id", userID,
+					"remote_addr", ipAddress,
+					"err", err,
+					"component", "rate_limit",
+				)
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			w.Header().Set("X-RateLimit-Remaining", strconv.Itoa(result.Remaining))
+			w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(result.ResetTime.Unix(), 10))
+
+			if !result.Allowed {
+				w.Header().Set("Retry-After", strconv.FormatInt(int64(time.Until(result.ResetTime).Seconds()), 10))
+				http.Error(w, "Rate limit exceeded. Please try again later.", http.StatusTooManyRequests)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
 
 // RateLimitMiddleware creates middleware for rate limiting using the provided rate limiter
 func RateLimitMiddleware(limiter service.RateLimiter, cfg *config.Config) func(http.Handler) http.Handler {

--- a/backend/internal/api/research/handler.go
+++ b/backend/internal/api/research/handler.go
@@ -1,0 +1,86 @@
+package research
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"papertrader/internal/api/auth"
+	svcresearch "papertrader/internal/service/research"
+	"papertrader/internal/util"
+)
+
+const (
+	maxQueryLen    = 2000
+	maxSymbolCount = 50
+)
+
+// answerer is the subset of svcresearch.AnswerService the handler depends on.
+// Extracting this interface keeps the handler testable without a full service.
+type answerer interface {
+	Ask(ctx context.Context, userID, query string, opts svcresearch.AskOpts) (*svcresearch.Answer, error)
+}
+
+// Handler handles research HTTP requests.
+type Handler struct {
+	svc answerer
+}
+
+func NewHandler(svc answerer) *Handler {
+	return &Handler{svc: svc}
+}
+
+// askRequest is the decoded body for POST /api/research/ask.
+type askRequest struct {
+	Query    string   `json:"query"`
+	Symbols  []string `json:"symbols"`
+	K        int      `json:"k"`
+	MinScore float64  `json:"min_score"`
+}
+
+// Ask handles POST /api/research/ask.
+func (h *Handler) Ask(w http.ResponseWriter, r *http.Request) {
+	// Read user identity from the request context populated by auth.JWTMiddleware,
+	// not from the X-User-ID header. The header pattern is safe only when
+	// StripUserHeaders is wired globally; reading from context fails closed if
+	// JWT middleware is missing from this route, even if the header scrubber is
+	// not in the chain.
+	userID, ok := auth.UserIDFromContext(r.Context())
+	if !ok {
+		http.Error(w, "Unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	var req askRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		util.WriteSafeError(w, http.StatusBadRequest, "invalid request body", err, "INVALID_REQUEST")
+		return
+	}
+
+	if req.Query == "" {
+		util.WriteSafeError(w, http.StatusBadRequest, "query is required", nil, "VALIDATION_ERROR")
+		return
+	}
+	if len(req.Query) > maxQueryLen {
+		util.WriteSafeError(w, http.StatusBadRequest, "query exceeds maximum length of 2000 characters", nil, "VALIDATION_ERROR")
+		return
+	}
+	if len(req.Symbols) > maxSymbolCount {
+		util.WriteSafeError(w, http.StatusBadRequest, "symbols list exceeds maximum of 50 entries", nil, "VALIDATION_ERROR")
+		return
+	}
+
+	answer, err := h.svc.Ask(r.Context(), userID, req.Query, svcresearch.AskOpts{
+		Symbols:  req.Symbols,
+		K:        req.K,
+		MinScore: req.MinScore,
+	})
+	if err != nil {
+		util.WriteSafeError(w, http.StatusInternalServerError, "research query failed", err, "INTERNAL_ERROR")
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(answer)
+}

--- a/backend/internal/api/research/handler_test.go
+++ b/backend/internal/api/research/handler_test.go
@@ -1,0 +1,121 @@
+package research
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"papertrader/internal/api/auth"
+	svcresearch "papertrader/internal/service/research"
+)
+
+// stubAnswerSvc satisfies the answerer interface for handler tests.
+type stubAnswerSvc struct {
+	answer *svcresearch.Answer
+	err    error
+}
+
+func (s *stubAnswerSvc) Ask(_ context.Context, _, _ string, _ svcresearch.AskOpts) (*svcresearch.Answer, error) {
+	return s.answer, s.err
+}
+
+func postAsk(t *testing.T, h *Handler, body string, userID string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, "/api/research/ask", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	if userID != "" {
+		req = req.WithContext(auth.WithUserID(req.Context(), userID))
+	}
+	w := httptest.NewRecorder()
+	h.Ask(w, req)
+	return w
+}
+
+func TestAsk_400OnEmptyQuery(t *testing.T) {
+	h := NewHandler(&stubAnswerSvc{})
+	w := postAsk(t, h, `{"query":""}`, "user-1")
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestAsk_400OnTooLongQuery(t *testing.T) {
+	h := NewHandler(&stubAnswerSvc{})
+	long := strings.Repeat("x", 2001)
+	body, _ := json.Marshal(map[string]string{"query": long})
+	w := postAsk(t, h, string(body), "user-1")
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+func TestAsk_200OnHappyPath(t *testing.T) {
+	expected := &svcresearch.Answer{
+		QueryID:   "abc123",
+		Answer:    "AAPL revenue was $X.",
+		Citations: []svcresearch.Citation{{ChunkID: "c1", SourceURL: "https://x.com", Excerpt: "text", Score: 0.9}},
+		Refused:   false,
+		LatencyMS: 42,
+	}
+	h := NewHandler(&stubAnswerSvc{answer: expected})
+	body, _ := json.Marshal(map[string]string{"query": "What is AAPL revenue?"})
+	w := postAsk(t, h, string(body), "user-1")
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+	var got svcresearch.Answer
+	if err := json.NewDecoder(bytes.NewReader(w.Body.Bytes())).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if got.QueryID != expected.QueryID {
+		t.Errorf("QueryID = %q, want %q", got.QueryID, expected.QueryID)
+	}
+	if got.Answer != expected.Answer {
+		t.Errorf("Answer = %q, want %q", got.Answer, expected.Answer)
+	}
+	if len(got.Citations) != 1 {
+		t.Errorf("Citations len = %d, want 1", len(got.Citations))
+	}
+}
+
+func TestAsk_200OnRefusal(t *testing.T) {
+	refused := &svcresearch.Answer{
+		QueryID:       "xyz",
+		Refused:       true,
+		RefusalReason: "forward_looking",
+		Citations:     []svcresearch.Citation{},
+		LatencyMS:     5,
+	}
+	h := NewHandler(&stubAnswerSvc{answer: refused})
+	body, _ := json.Marshal(map[string]string{"query": "Will AAPL go up?"})
+	w := postAsk(t, h, string(body), "user-1")
+	if w.Code != http.StatusOK {
+		t.Errorf("refusal should return 200, got %d", w.Code)
+	}
+	var got svcresearch.Answer
+	if err := json.NewDecoder(bytes.NewReader(w.Body.Bytes())).Decode(&got); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if !got.Refused {
+		t.Error("expected Refused=true in response")
+	}
+	if got.RefusalReason != "forward_looking" {
+		t.Errorf("RefusalReason = %q, want %q", got.RefusalReason, "forward_looking")
+	}
+}
+
+func TestAsk_401OnMissingUserID(t *testing.T) {
+	h := NewHandler(&stubAnswerSvc{})
+	req := httptest.NewRequest(http.MethodPost, "/api/research/ask",
+		strings.NewReader(`{"query":"test"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.Ask(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", w.Code)
+	}
+}

--- a/backend/internal/api/research/routes.go
+++ b/backend/internal/api/research/routes.go
@@ -1,0 +1,44 @@
+package research
+
+import (
+	"net/http"
+	"time"
+
+	"papertrader/internal/api/auth"
+	"papertrader/internal/api/middleware"
+	"papertrader/internal/config"
+	"papertrader/internal/service"
+
+	"github.com/gorilla/mux"
+)
+
+// /api/research/ask is the most expensive endpoint (one LLM round-trip per
+// call), so it gets a tighter per-route bucket than the global default.
+//
+// Endpoint requires JWT, so anon traffic can't reach this limiter — the IP
+// cap exists as a backup against abuse from a single source (or one client
+// burning through many auth tokens). Set generously above the user limit so
+// real users behind shared NAT aren't punished.
+const (
+	askBucket    = "research_ask"
+	askUserLimit = 10
+	askIPLimit   = 30
+	askWindow    = time.Minute
+)
+
+// Mount attaches research routes to r. r should be a subrouter scoped to
+// /api/research so paths here are registered relative to that prefix.
+func Mount(r *mux.Router, h *Handler, jwtService *service.JWTService, rateLimiter service.RateLimiter, cfg *config.Config) {
+	r.StrictSlash(false)
+	r.Use(auth.JWTMiddleware(jwtService, cfg))
+
+	askHandler := http.HandlerFunc(h.Ask)
+	if rateLimiter != nil {
+		rl := middleware.RateLimitMiddlewareCustom(rateLimiter, cfg, askBucket, askUserLimit, askIPLimit, askWindow)
+		r.Handle("/ask", rl(askHandler)).Methods("POST", "OPTIONS")
+		r.Handle("/ask/", rl(askHandler)).Methods("POST", "OPTIONS")
+	} else {
+		r.Handle("/ask", askHandler).Methods("POST", "OPTIONS")
+		r.Handle("/ask/", askHandler).Methods("POST", "OPTIONS")
+	}
+}

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -14,22 +14,30 @@ const (
 )
 
 type Config struct {
-	Port           string
-	MarketStackKey string
-	DatabaseURL    string
-	JWTSecret      string
-	FrontendURL    string
-	RedisURL       string
-	RedisPassword  string
-	RedisDB        int
-	Environment    string
-	ResendAPIKey   string
-	FromEmail      string
-	LogLevel       string
-	GoogleClientID string
-	MigrateOnStart bool
-	RequestTimeout time.Duration
-	MaxRequestSize int64
+	Port             string
+	MarketStackKey   string
+	DatabaseURL      string
+	JWTSecret        string
+	FrontendURL      string
+	RedisURL         string
+	RedisPassword    string
+	RedisDB          int
+	Environment      string
+	ResendAPIKey     string
+	FromEmail        string
+	LogLevel         string
+	GoogleClientID   string
+	MigrateOnStart   bool
+	RequestTimeout   time.Duration
+	MaxRequestSize   int64
+	GeminiAPIKey           string // env: GEMINI_API_KEY — reserved for Phase 4 LLM generation
+	GroqAPIKey             string // env: GROQ_API_KEY — llama-3.3-70b-versatile via Groq
+	VoyageAPIKey           string // env: VOYAGE_API_KEY
+	SecUserAgent           string // env: SEC_USER_AGENT
+	ResearchEnabled          bool   // env: RESEARCH_ENABLED
+	ResearchTickerUniverse   string // env: RESEARCH_TICKER_UNIVERSE — comma-separated default ingest set
+	ResearchIngestSchedule   string // env: RESEARCH_INGEST_SCHEDULE — cron expression, default "0 2 1 * *" (2 AM UTC, 1st of month)
+	ResearchIngestMaxFilings int    // env: RESEARCH_INGEST_MAX_FILINGS — per ticker, default 3
 }
 
 // IsProduction returns true if the environment is set to "production"
@@ -57,9 +65,17 @@ func Load() (*Config, error) {
 		FromEmail:      getEnv("FROM_EMAIL", ""),
 		LogLevel:       getEnv("LOG_LEVEL", "info"),
 		GoogleClientID: getEnv("GOOGLE_CLIENT_ID", ""),
-		MigrateOnStart: getEnvBool("MIGRATE_ON_START", false),
-		RequestTimeout: getEnvDuration("REQUEST_TIMEOUT_SECONDS", defaultRequestTimeout),
-		MaxRequestSize: getEnvInt64("MAX_REQUEST_SIZE", defaultMaxRequestSize),
+		MigrateOnStart:  getEnvBool("MIGRATE_ON_START", false),
+		RequestTimeout:  getEnvDuration("REQUEST_TIMEOUT_SECONDS", defaultRequestTimeout),
+		MaxRequestSize:  getEnvInt64("MAX_REQUEST_SIZE", defaultMaxRequestSize),
+		GeminiAPIKey:           getEnv("GEMINI_API_KEY", ""),
+		GroqAPIKey:             getEnv("GROQ_API_KEY", ""),
+		VoyageAPIKey:           getEnv("VOYAGE_API_KEY", ""),
+		SecUserAgent:           getEnv("SEC_USER_AGENT", "PaperTrader research@example.com"),
+		ResearchEnabled:          getEnvBool("RESEARCH_ENABLED", false),
+		ResearchTickerUniverse:   getEnv("RESEARCH_TICKER_UNIVERSE", "AAPL,MSFT,NVDA,GOOGL,AMZN,META,TSLA,COIN,JPM,V"),
+		ResearchIngestSchedule:   getEnv("RESEARCH_INGEST_SCHEDULE", "0 2 1 * *"),
+		ResearchIngestMaxFilings: getEnvInt("RESEARCH_INGEST_MAX_FILINGS", 3),
 	}
 
 	if strings.ToLower(env) == "production" {
@@ -110,6 +126,18 @@ func validateProductionConfig(cfg *Config) error {
 
 	if cfg.FrontendURL == "" || cfg.FrontendURL == "http://localhost:3000" {
 		return fmt.Errorf("FRONTEND_URL must be set to production domain in production")
+	}
+
+	if cfg.ResearchEnabled {
+		if cfg.VoyageAPIKey == "" {
+			return fmt.Errorf("VOYAGE_API_KEY is required in production when RESEARCH_ENABLED=true")
+		}
+		if cfg.GroqAPIKey == "" {
+			return fmt.Errorf("GROQ_API_KEY is required in production when RESEARCH_ENABLED=true")
+		}
+		if !strings.Contains(cfg.SecUserAgent, "@") {
+			return fmt.Errorf("SEC_USER_AGENT must contain a valid contact email (with '@') in production")
+		}
 	}
 
 	return nil

--- a/backend/internal/config/postgres.go
+++ b/backend/internal/config/postgres.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log/slog"
@@ -38,6 +39,16 @@ func ConnectPostgreSQL(cfg *Config) (*sql.DB, error) {
 		}
 
 		slog.Info("connected to PostgreSQL successfully")
+
+		// Best-effort: enable pgvector. If the image doesn't have the extension the
+		// migration will fail loudly later — this is just a convenience so dev
+		// containers don't require a separate CREATE EXTENSION step.
+		if _, extErr := db.ExecContext(context.Background(), "CREATE EXTENSION IF NOT EXISTS vector;"); extErr != nil {
+			slog.Warn("could not create pgvector extension; ensure image is pgvector/pgvector:pg15", "err", extErr)
+		} else {
+			slog.Info("pgvector extension ready")
+		}
+
 		return db, nil
 	}
 

--- a/backend/internal/data/research_store.go
+++ b/backend/internal/data/research_store.go
@@ -1,0 +1,381 @@
+package data
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/lib/pq"
+)
+
+// Document is one source filing or article stored before chunking.
+type Document struct {
+	ID         string
+	SourceType string
+	SourceURL  string
+	Symbol     string
+	Title      string
+	FiledAt    *time.Time
+	Metadata   []byte // raw JSONB
+	FetchedAt  time.Time
+}
+
+// Chunk is a text fragment derived from a Document.
+type Chunk struct {
+	ID         string
+	DocumentID string
+	ChunkIndex int
+	Text       string
+	TokenCount int
+	Section    string
+}
+
+// ChunkHit is a retrieval result combining embedding score with chunk/doc metadata.
+type ChunkHit struct {
+	ChunkID    string
+	DocumentID string
+	Text       string
+	Section    string
+	SourceURL  string
+	Symbol     string
+	FiledAt    *time.Time
+	Score      float64
+}
+
+// SearchOpts controls the vector search query.
+type SearchOpts struct {
+	Symbols     []string
+	SourceTypes []string
+	Since       *time.Time
+	K           int
+}
+
+// ResearchQuery is one row in the research_queries audit table.
+type ResearchQuery struct {
+	ID               string
+	UserID           *string
+	QueryText        string
+	AnswerText       *string
+	Refused          bool
+	RefusalReason    *string
+	Citations        []byte
+	RetrievalMS      *int
+	GenerationMS     *int
+	TotalMS          *int
+	EmbedTokens      *int
+	PromptTokens     *int
+	CompletionTokens *int
+	CostUSDMicros    *int
+	Model            *string
+}
+
+// ---- DocumentsStore ----
+
+type DocumentsStore struct {
+	db DBTX
+}
+
+func NewDocumentsStore(db DBTX) *DocumentsStore {
+	return &DocumentsStore{db: db}
+}
+
+func (s *DocumentsStore) Upsert(ctx context.Context, doc Document) error {
+	query := `
+INSERT INTO documents (id, source_type, source_url, symbol, title, filed_at, metadata)
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (source_url) DO UPDATE SET
+    source_type = EXCLUDED.source_type,
+    symbol      = EXCLUDED.symbol,
+    title       = EXCLUDED.title,
+    filed_at    = EXCLUDED.filed_at,
+    metadata    = EXCLUDED.metadata,
+    fetched_at  = CURRENT_TIMESTAMP`
+
+	metadata := doc.Metadata
+	if metadata == nil {
+		metadata = []byte("{}")
+	}
+
+	_, err := s.db.ExecContext(ctx, query,
+		doc.ID, doc.SourceType, doc.SourceURL,
+		doc.Symbol, doc.Title, doc.FiledAt,
+		metadata,
+	)
+	return err
+}
+
+func (s *DocumentsStore) GetByID(ctx context.Context, id string) (*Document, error) {
+	query := `
+SELECT id, source_type, source_url, symbol, title, filed_at, metadata, fetched_at
+FROM documents WHERE id = $1`
+	return s.scanDocument(ctx, query, id)
+}
+
+func (s *DocumentsStore) GetBySourceURL(ctx context.Context, url string) (*Document, error) {
+	query := `
+SELECT id, source_type, source_url, symbol, title, filed_at, metadata, fetched_at
+FROM documents WHERE source_url = $1`
+	return s.scanDocument(ctx, query, url)
+}
+
+func (s *DocumentsStore) scanDocument(ctx context.Context, query string, arg interface{}) (*Document, error) {
+	var d Document
+	var symbol, title sql.NullString
+	var filedAt sql.NullTime
+	err := s.db.QueryRowContext(ctx, query, arg).Scan(
+		&d.ID, &d.SourceType, &d.SourceURL,
+		&symbol, &title, &filedAt,
+		&d.Metadata, &d.FetchedAt,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if symbol.Valid {
+		d.Symbol = symbol.String
+	}
+	if title.Valid {
+		d.Title = title.String
+	}
+	if filedAt.Valid {
+		d.FiledAt = &filedAt.Time
+	}
+	return &d, nil
+}
+
+// ---- ChunksStore ----
+
+type ChunksStore struct {
+	db DBTX
+}
+
+func NewChunksStore(db DBTX) *ChunksStore {
+	return &ChunksStore{db: db}
+}
+
+// BulkInsert inserts all chunks in a single multi-row statement.
+// ON CONFLICT DO NOTHING keeps this idempotent on re-ingest.
+func (s *ChunksStore) BulkInsert(ctx context.Context, chunks []Chunk) error {
+	if len(chunks) == 0 {
+		return nil
+	}
+
+	placeholders := make([]string, 0, len(chunks))
+	args := make([]interface{}, 0, len(chunks)*5)
+	idx := 1
+	for _, c := range chunks {
+		placeholders = append(placeholders, fmt.Sprintf("($%d,$%d,$%d,$%d,$%d,$%d)",
+			idx, idx+1, idx+2, idx+3, idx+4, idx+5))
+		args = append(args, c.ID, c.DocumentID, c.ChunkIndex, c.Text, c.TokenCount, c.Section)
+		idx += 6
+	}
+
+	query := `INSERT INTO chunks (id, document_id, chunk_index, text, token_count, section)
+VALUES ` + strings.Join(placeholders, ",") + ` ON CONFLICT (document_id, chunk_index) DO NOTHING`
+
+	_, err := s.db.ExecContext(ctx, query, args...)
+	return err
+}
+
+// GetByID fetches one chunk by its primary key. Returns sql.ErrNoRows if absent.
+func (s *ChunksStore) GetByID(ctx context.Context, id string) (*Chunk, error) {
+	query := `
+SELECT id, document_id, chunk_index, text, token_count, section
+FROM chunks WHERE id = $1`
+
+	var c Chunk
+	var section sql.NullString
+	err := s.db.QueryRowContext(ctx, query, id).Scan(
+		&c.ID, &c.DocumentID, &c.ChunkIndex, &c.Text, &c.TokenCount, &section,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if section.Valid {
+		c.Section = section.String
+	}
+	return &c, nil
+}
+
+func (s *ChunksStore) GetByDocumentID(ctx context.Context, docID string) ([]Chunk, error) {
+	query := `
+SELECT id, document_id, chunk_index, text, token_count, section
+FROM chunks WHERE document_id = $1 ORDER BY chunk_index`
+
+	rows, err := s.db.QueryContext(ctx, query, docID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var chunks []Chunk
+	for rows.Next() {
+		var c Chunk
+		var section sql.NullString
+		if err := rows.Scan(&c.ID, &c.DocumentID, &c.ChunkIndex, &c.Text, &c.TokenCount, &section); err != nil {
+			return nil, err
+		}
+		if section.Valid {
+			c.Section = section.String
+		}
+		chunks = append(chunks, c)
+	}
+	return chunks, rows.Err()
+}
+
+// ---- EmbeddingsStore ----
+
+type EmbeddingsStore struct {
+	db DBTX
+}
+
+func NewEmbeddingsStore(db DBTX) *EmbeddingsStore {
+	return &EmbeddingsStore{db: db}
+}
+
+// Upsert stores (or replaces) an embedding for a chunk.
+// lib/pq has no native []float32 → vector binding, so we format the literal
+// ourselves and cast it in SQL with $1::vector.
+func (s *EmbeddingsStore) Upsert(ctx context.Context, chunkID string, vec []float32, model string) error {
+	query := `
+INSERT INTO chunk_embeddings (chunk_id, embedding, model)
+VALUES ($1, $2::vector, $3)
+ON CONFLICT (chunk_id) DO UPDATE SET
+    embedding   = EXCLUDED.embedding,
+    model       = EXCLUDED.model,
+    embedded_at = CURRENT_TIMESTAMP`
+
+	_, err := s.db.ExecContext(ctx, query, chunkID, vectorLiteral(vec), model)
+	return err
+}
+
+func (s *EmbeddingsStore) Exists(ctx context.Context, chunkID string) (bool, error) {
+	var exists bool
+	err := s.db.QueryRowContext(ctx,
+		`SELECT EXISTS(SELECT 1 FROM chunk_embeddings WHERE chunk_id = $1)`, chunkID,
+	).Scan(&exists)
+	return exists, err
+}
+
+// Search runs a cosine-similarity ANN query using the HNSW index.
+// SET (without LOCAL) is connection-scoped. On *sql.DB the pool may assign a
+// different connection for the SET and the SELECT, but the setting is harmless
+// if it persists on a reused conn — it only affects recall quality, not
+// correctness. Using LOCAL would require a transaction, which complicates the
+// DBTX interface for minimal benefit.
+func (s *EmbeddingsStore) Search(ctx context.Context, vec []float32, opts SearchOpts) ([]ChunkHit, error) {
+	// Raise HNSW ef_search for better recall. Advisory: ignored if pgvector
+	// doesn't support the GUC (older versions).
+	_, _ = s.db.ExecContext(ctx, "SET hnsw.ef_search = 60")
+
+	k := opts.K
+	if k <= 0 {
+		k = 8
+	}
+
+	var symbols interface{}
+	if len(opts.Symbols) > 0 {
+		symbols = pq.Array(opts.Symbols)
+	}
+	var sourceTypes interface{}
+	if len(opts.SourceTypes) > 0 {
+		sourceTypes = pq.Array(opts.SourceTypes)
+	}
+
+	query := `
+SELECT c.id, c.document_id, c.text, c.section, d.source_url, d.symbol, d.filed_at,
+       1 - (e.embedding <=> $1::vector) AS score
+FROM chunk_embeddings e
+JOIN chunks c ON c.id = e.chunk_id
+JOIN documents d ON d.id = c.document_id
+WHERE ($2::text[] IS NULL OR d.symbol = ANY($2))
+  AND ($3::text[] IS NULL OR d.source_type = ANY($3))
+  AND ($4::timestamp IS NULL OR d.filed_at >= $4)
+ORDER BY e.embedding <=> $1::vector
+LIMIT $5`
+
+	rows, err := s.db.QueryContext(ctx, query,
+		vectorLiteral(vec), symbols, sourceTypes, opts.Since, k,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var hits []ChunkHit
+	for rows.Next() {
+		var h ChunkHit
+		var section, symbol sql.NullString
+		var filedAt sql.NullTime
+		if err := rows.Scan(&h.ChunkID, &h.DocumentID, &h.Text, &section,
+			&h.SourceURL, &symbol, &filedAt, &h.Score); err != nil {
+			return nil, err
+		}
+		if section.Valid {
+			h.Section = section.String
+		}
+		if symbol.Valid {
+			h.Symbol = symbol.String
+		}
+		if filedAt.Valid {
+			h.FiledAt = &filedAt.Time
+		}
+		hits = append(hits, h)
+	}
+	return hits, rows.Err()
+}
+
+// vectorLiteral formats a []float32 as the pgvector text literal "[0.1,0.2,...]".
+// This is necessary because lib/pq has no native binding for the vector type.
+func vectorLiteral(vec []float32) string {
+	if len(vec) == 0 {
+		return "[]"
+	}
+	sb := strings.Builder{}
+	sb.WriteByte('[')
+	for i, v := range vec {
+		if i > 0 {
+			sb.WriteByte(',')
+		}
+		sb.WriteString(fmt.Sprintf("%g", v))
+	}
+	sb.WriteByte(']')
+	return sb.String()
+}
+
+// ---- ResearchQueriesStore ----
+
+type ResearchQueriesStore struct {
+	db DBTX
+}
+
+func NewResearchQueriesStore(db DBTX) *ResearchQueriesStore {
+	return &ResearchQueriesStore{db: db}
+}
+
+func (s *ResearchQueriesStore) Insert(ctx context.Context, q ResearchQuery) error {
+	citations := q.Citations
+	if citations == nil {
+		citations = []byte("[]")
+	}
+
+	query := `
+INSERT INTO research_queries
+  (id, user_id, query_text, answer_text, refused, refusal_reason, citations,
+   retrieval_ms, generation_ms, total_ms, embed_tokens, prompt_tokens,
+   completion_tokens, cost_usd_micros, model)
+VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15)`
+
+	_, err := s.db.ExecContext(ctx, query,
+		q.ID, q.UserID, q.QueryText, q.AnswerText,
+		q.Refused, q.RefusalReason, citations,
+		q.RetrievalMS, q.GenerationMS, q.TotalMS,
+		q.EmbedTokens, q.PromptTokens, q.CompletionTokens,
+		q.CostUSDMicros, q.Model,
+	)
+	return err
+}

--- a/backend/internal/data/research_store_integration_test.go
+++ b/backend/internal/data/research_store_integration_test.go
@@ -1,0 +1,138 @@
+// Package data — integration tests for the research stores.
+//
+// Run with a real Postgres that has the pgvector extension and the research
+// schema applied:
+//
+//	INTEGRATION_DB_URL=postgres://postgres:postgres@localhost/papertrader?sslmode=disable \
+//	  go test -tags=integration ./internal/data/
+//
+// The test applies the up migration, exercises all stores, then cleans up via
+// the down migration. It is safe to run multiple times.
+
+//go:build integration
+
+package data
+
+import (
+	"context"
+	"database/sql"
+	"math"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	_ "github.com/lib/pq"
+)
+
+func TestResearchStores_Integration(t *testing.T) {
+	dsn := os.Getenv("INTEGRATION_DB_URL")
+	if dsn == "" {
+		t.Skip("INTEGRATION_DB_URL not set; skipping integration test")
+	}
+
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	defer db.Close()
+
+	if err := db.Ping(); err != nil {
+		t.Fatalf("ping db: %v", err)
+	}
+
+	// Enable extension (idempotent; requires pgvector/pgvector image).
+	if _, err := db.Exec("CREATE EXTENSION IF NOT EXISTS vector"); err != nil {
+		t.Fatalf("create extension: %v", err)
+	}
+
+	_, thisFile, _, _ := runtime.Caller(0)
+	migrationsDir := filepath.Join(filepath.Dir(thisFile), "../migrations/sql")
+
+	applySQL := func(t *testing.T, file string) {
+		t.Helper()
+		body, err := os.ReadFile(filepath.Join(migrationsDir, file))
+		if err != nil {
+			t.Fatalf("read %s: %v", file, err)
+		}
+		if _, err := db.Exec(string(body)); err != nil {
+			t.Fatalf("exec %s: %v", file, err)
+		}
+	}
+
+	// Apply schema; always clean up.
+	applySQL(t, "0009_research_schema.up.sql")
+	t.Cleanup(func() { applySQL(t, "0009_research_schema.down.sql") })
+
+	ctx := context.Background()
+
+	docStore := NewDocumentsStore(db)
+	chunkStore := NewChunksStore(db)
+	embStore := NewEmbeddingsStore(db)
+
+	filedAt := time.Date(2024, 10, 30, 0, 0, 0, 0, time.UTC)
+	doc := Document{
+		ID:         "integ-doc-1",
+		SourceType: "sec_filing",
+		SourceURL:  "https://sec.gov/integ/test/1",
+		Symbol:     "AAPL",
+		Title:      "10-K 2024 Integration",
+		FiledAt:    &filedAt,
+	}
+	if err := docStore.Upsert(ctx, doc); err != nil {
+		t.Fatalf("Upsert doc: %v", err)
+	}
+
+	// Three 1024-dim deterministic embedding patterns: one-hot at indices 0, 100, 200.
+	makeVec := func(hotIdx int) []float32 {
+		v := make([]float32, 1024)
+		v[hotIdx] = 1.0
+		return v
+	}
+
+	chunks := []Chunk{
+		{ID: "integ-chunk-0", DocumentID: "integ-doc-1", ChunkIndex: 0, Text: "Apple supply chain risk factors", TokenCount: 6, Section: "Item 1A"},
+		{ID: "integ-chunk-1", DocumentID: "integ-doc-1", ChunkIndex: 1, Text: "Management discussion and analysis", TokenCount: 5, Section: "Item 7"},
+		{ID: "integ-chunk-2", DocumentID: "integ-doc-1", ChunkIndex: 2, Text: "Financial statements and notes", TokenCount: 5, Section: "Item 8"},
+	}
+	if err := chunkStore.BulkInsert(ctx, chunks); err != nil {
+		t.Fatalf("BulkInsert: %v", err)
+	}
+
+	vecs := [][]float32{makeVec(0), makeVec(100), makeVec(200)}
+	model := "voyage-finance-2"
+	for i, c := range chunks {
+		if err := embStore.Upsert(ctx, c.ID, vecs[i], model); err != nil {
+			t.Fatalf("Upsert embedding %d: %v", i, err)
+		}
+	}
+
+	// Query close to chunk-0 (hot at index 0).
+	query := makeVec(0)
+	// Nudge slightly to keep score < 1.0 while ensuring chunk-0 wins clearly.
+	query[1] = 0.01
+	// Normalize.
+	var sum float64
+	for _, v := range query {
+		sum += float64(v) * float64(v)
+	}
+	norm := float32(math.Sqrt(sum))
+	for i := range query {
+		query[i] /= norm
+	}
+
+	hits, err := embStore.Search(ctx, query, SearchOpts{K: 3})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) == 0 {
+		t.Fatal("Search returned no hits")
+	}
+	if hits[0].ChunkID != "integ-chunk-0" {
+		t.Errorf("top hit = %q, want integ-chunk-0", hits[0].ChunkID)
+	}
+	if hits[0].Score < 0.9 {
+		t.Errorf("top hit score = %.4f, want >= 0.9", hits[0].Score)
+	}
+}

--- a/backend/internal/data/research_store_test.go
+++ b/backend/internal/data/research_store_test.go
@@ -1,0 +1,267 @@
+package data
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	sqlmock "github.com/DATA-DOG/go-sqlmock"
+)
+
+func TestDocumentsStore_Upsert(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec(`INSERT INTO documents`).
+		WithArgs(
+			"docid1", "sec_filing", "https://example.com/filing", "AAPL",
+			"10-K 2024", sqlmock.AnyArg(), sqlmock.AnyArg(),
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	store := NewDocumentsStore(db)
+	filedAt := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	doc := Document{
+		ID:         "docid1",
+		SourceType: "sec_filing",
+		SourceURL:  "https://example.com/filing",
+		Symbol:     "AAPL",
+		Title:      "10-K 2024",
+		FiledAt:    &filedAt,
+	}
+	if err := store.Upsert(context.Background(), doc); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestDocumentsStore_GetByID(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	now := time.Now()
+	filedAt := time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)
+	rows := sqlmock.NewRows([]string{
+		"id", "source_type", "source_url", "symbol", "title", "filed_at", "metadata", "fetched_at",
+	}).AddRow("docid1", "sec_filing", "https://example.com/filing", "AAPL", "10-K 2024", filedAt, []byte("{}"), now)
+
+	mock.ExpectQuery(`SELECT .* FROM documents WHERE id`).
+		WithArgs("docid1").
+		WillReturnRows(rows)
+
+	store := NewDocumentsStore(db)
+	doc, err := store.GetByID(context.Background(), "docid1")
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if doc == nil {
+		t.Fatal("expected document, got nil")
+	}
+	if doc.Symbol != "AAPL" {
+		t.Errorf("symbol = %q, want AAPL", doc.Symbol)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestDocumentsStore_GetByID_NotFound(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(`SELECT .* FROM documents WHERE id`).
+		WithArgs("missing").
+		WillReturnRows(sqlmock.NewRows([]string{"id"}))
+
+	store := NewDocumentsStore(db)
+	doc, err := store.GetByID(context.Background(), "missing")
+	if err != nil {
+		t.Fatalf("GetByID: %v", err)
+	}
+	if doc != nil {
+		t.Errorf("expected nil for missing doc, got %+v", doc)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestChunksStore_BulkInsert(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec(`INSERT INTO chunks`).
+		WithArgs(
+			"c1", "doc1", 0, "text one", 10, "",
+			"c2", "doc1", 1, "text two", 8, "Item 1A",
+		).
+		WillReturnResult(sqlmock.NewResult(2, 2))
+
+	store := NewChunksStore(db)
+	chunks := []Chunk{
+		{ID: "c1", DocumentID: "doc1", ChunkIndex: 0, Text: "text one", TokenCount: 10},
+		{ID: "c2", DocumentID: "doc1", ChunkIndex: 1, Text: "text two", TokenCount: 8, Section: "Item 1A"},
+	}
+	if err := store.BulkInsert(context.Background(), chunks); err != nil {
+		t.Fatalf("BulkInsert: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestChunksStore_BulkInsert_Empty(t *testing.T) {
+	db, _, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	store := NewChunksStore(db)
+	// No SQL should be issued for an empty slice.
+	if err := store.BulkInsert(context.Background(), nil); err != nil {
+		t.Fatalf("BulkInsert empty: %v", err)
+	}
+}
+
+func TestEmbeddingsStore_Upsert_VectorLiteral(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	// The vector must arrive as the pgvector text literal format.
+	mock.ExpectExec(`INSERT INTO chunk_embeddings`).
+		WithArgs("chunk1", "[1,0,0]", "gemini-embedding-001").
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	store := NewEmbeddingsStore(db)
+	vec := []float32{1, 0, 0}
+	if err := store.Upsert(context.Background(), "chunk1", vec, "gemini-embedding-001"); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestEmbeddingsStore_Exists(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectQuery(`SELECT EXISTS`).
+		WithArgs("chunk1").
+		WillReturnRows(sqlmock.NewRows([]string{"exists"}).AddRow(true))
+
+	store := NewEmbeddingsStore(db)
+	ok, err := store.Exists(context.Background(), "chunk1")
+	if err != nil {
+		t.Fatalf("Exists: %v", err)
+	}
+	if !ok {
+		t.Error("expected exists=true")
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestEmbeddingsStore_Search(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	filedAt := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// SET (no LOCAL) is connection-scoped; best-effort, so we allow it.
+	mock.ExpectExec(`SET hnsw.ef_search`).WillReturnResult(sqlmock.NewResult(0, 0))
+
+	mock.ExpectQuery(`SELECT c\.id`).
+		WillReturnRows(sqlmock.NewRows([]string{
+			"id", "document_id", "text", "section", "source_url", "symbol", "filed_at", "score",
+		}).AddRow("c1", "doc1", "some text", "Item 1A", "https://sec.gov/f", "AAPL", filedAt, 0.92))
+
+	store := NewEmbeddingsStore(db)
+	vec := []float32{1, 0, 0}
+	hits, err := store.Search(context.Background(), vec, SearchOpts{K: 5})
+	if err != nil {
+		t.Fatalf("Search: %v", err)
+	}
+	if len(hits) != 1 {
+		t.Fatalf("expected 1 hit, got %d", len(hits))
+	}
+	if hits[0].Score < 0.9 {
+		t.Errorf("score = %.3f, want >= 0.9", hits[0].Score)
+	}
+	if hits[0].Symbol != "AAPL" {
+		t.Errorf("symbol = %q, want AAPL", hits[0].Symbol)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestResearchQueriesStore_Insert(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	mock.ExpectExec(`INSERT INTO research_queries`).
+		WithArgs(
+			"qid1", nil, "What is AAPL revenue?", nil,
+			false, nil, sqlmock.AnyArg(),
+			nil, nil, nil, nil, nil, nil, nil, nil,
+		).
+		WillReturnResult(sqlmock.NewResult(1, 1))
+
+	store := NewResearchQueriesStore(db)
+	q := ResearchQuery{
+		ID:        "qid1",
+		QueryText: "What is AAPL revenue?",
+	}
+	if err := store.Insert(context.Background(), q); err != nil {
+		t.Fatalf("Insert: %v", err)
+	}
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestVectorLiteral(t *testing.T) {
+	cases := []struct {
+		in   []float32
+		want string
+	}{
+		{[]float32{}, "[]"},
+		{[]float32{1, 0, 0}, "[1,0,0]"},
+		{[]float32{0.5, -0.5}, "[0.5,-0.5]"},
+	}
+	for _, tc := range cases {
+		got := vectorLiteral(tc.in)
+		if got != tc.want {
+			t.Errorf("vectorLiteral(%v) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/backend/internal/migrations/sql/0009_research_schema.down.sql
+++ b/backend/internal/migrations/sql/0009_research_schema.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS research_queries;
+DROP TABLE IF EXISTS chunk_embeddings;
+DROP TABLE IF EXISTS chunks;
+DROP TABLE IF EXISTS documents;

--- a/backend/internal/migrations/sql/0009_research_schema.up.sql
+++ b/backend/internal/migrations/sql/0009_research_schema.up.sql
@@ -1,0 +1,57 @@
+CREATE TABLE IF NOT EXISTS documents (
+    id              VARCHAR(64) PRIMARY KEY,
+    source_type     VARCHAR(20) NOT NULL,
+    -- source_url is rendered as a clickable link in the frontend. The CHECK
+    -- prevents javascript:/data: URLs from a poisoned ingest source from ever
+    -- reaching the DOM; ingest code performs the same check before insert.
+    source_url      TEXT NOT NULL CHECK (source_url ~ '^https?://'),
+    symbol          VARCHAR(10),
+    title           TEXT,
+    filed_at        TIMESTAMP,
+    metadata        JSONB NOT NULL DEFAULT '{}',
+    fetched_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(source_url)
+);
+CREATE INDEX IF NOT EXISTS idx_documents_symbol_filed_at ON documents(symbol, filed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_documents_source_type ON documents(source_type);
+
+CREATE TABLE IF NOT EXISTS chunks (
+    id              VARCHAR(64) PRIMARY KEY,
+    document_id     VARCHAR(64) NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+    chunk_index     INTEGER NOT NULL,
+    text            TEXT NOT NULL,
+    token_count     INTEGER NOT NULL,
+    section         TEXT,
+    UNIQUE(document_id, chunk_index)
+);
+CREATE INDEX IF NOT EXISTS idx_chunks_document_id ON chunks(document_id);
+
+CREATE TABLE IF NOT EXISTS chunk_embeddings (
+    chunk_id        VARCHAR(64) PRIMARY KEY REFERENCES chunks(id) ON DELETE CASCADE,
+    embedding       vector(768) NOT NULL,
+    model           VARCHAR(64) NOT NULL,
+    embedded_at     TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_chunk_embeddings_vec
+  ON chunk_embeddings USING hnsw (embedding vector_cosine_ops);
+
+CREATE TABLE IF NOT EXISTS research_queries (
+    id              VARCHAR(64) PRIMARY KEY,
+    user_id         VARCHAR(255) REFERENCES users(id),
+    query_text      TEXT NOT NULL,
+    answer_text     TEXT,
+    refused         BOOLEAN NOT NULL DEFAULT FALSE,
+    refusal_reason  VARCHAR(64),
+    citations       JSONB NOT NULL DEFAULT '[]',
+    retrieval_ms    INTEGER,
+    generation_ms   INTEGER,
+    total_ms        INTEGER,
+    embed_tokens    INTEGER,
+    prompt_tokens   INTEGER,
+    completion_tokens INTEGER,
+    cost_usd_micros INTEGER,
+    model           VARCHAR(64),
+    created_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX IF NOT EXISTS idx_research_queries_user_id ON research_queries(user_id);
+CREATE INDEX IF NOT EXISTS idx_research_queries_created_at ON research_queries(created_at DESC);

--- a/backend/internal/migrations/sql/0010_recreate_chunk_embeddings_for_voyage.down.sql
+++ b/backend/internal/migrations/sql/0010_recreate_chunk_embeddings_for_voyage.down.sql
@@ -1,0 +1,16 @@
+-- DESTRUCTIVE: rolling back drops every 1024-dim Voyage embedding and
+-- recreates the table at 768 dims (Gemini). There is no recovery path —
+-- after rollback, re-run `cmd/ingest` against a Gemini-compatible embedder
+-- to repopulate. The chunks table is preserved.
+
+DROP INDEX IF EXISTS idx_chunk_embeddings_vec;
+DROP TABLE IF EXISTS chunk_embeddings;
+
+CREATE TABLE chunk_embeddings (
+    chunk_id    VARCHAR(64) PRIMARY KEY REFERENCES chunks(id) ON DELETE CASCADE,
+    embedding   vector(768) NOT NULL,
+    model       VARCHAR(64) NOT NULL,
+    embedded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_chunk_embeddings_vec
+  ON chunk_embeddings USING hnsw (embedding vector_cosine_ops);

--- a/backend/internal/migrations/sql/0010_recreate_chunk_embeddings_for_voyage.up.sql
+++ b/backend/internal/migrations/sql/0010_recreate_chunk_embeddings_for_voyage.up.sql
@@ -1,0 +1,26 @@
+-- DESTRUCTIVE: drops and recreates chunk_embeddings to widen the vector
+-- column from 768 dims (Gemini) to 1024 dims (Voyage finance-2). pgvector
+-- does not allow ALTER COLUMN TYPE on vector(N), so a wipe-and-recreate is
+-- the only path.
+--
+-- Effect: every row in chunk_embeddings is lost. The chunks table is
+-- preserved so the ingest pipeline's backfill path (Pipeline.ingestFiling
+-- detects missing embeddings via embeddings.Exists and re-embeds each
+-- chunk) restores embeddings on the next `cmd/ingest` run. Operators MUST
+-- re-run ingest after this migration applies, otherwise retrieval returns
+-- nothing.
+--
+-- If this migration ever runs against a database that already has 1024-dim
+-- rows, those rows are also lost. Treat re-running as a destructive op.
+
+DROP INDEX IF EXISTS idx_chunk_embeddings_vec;
+DROP TABLE IF EXISTS chunk_embeddings;
+
+CREATE TABLE chunk_embeddings (
+    chunk_id    VARCHAR(64) PRIMARY KEY REFERENCES chunks(id) ON DELETE CASCADE,
+    embedding   vector(1024) NOT NULL,
+    model       VARCHAR(64) NOT NULL,
+    embedded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+CREATE INDEX idx_chunk_embeddings_vec
+  ON chunk_embeddings USING hnsw (embedding vector_cosine_ops);

--- a/backend/internal/service/memory_rate_limiter.go
+++ b/backend/internal/service/memory_rate_limiter.go
@@ -25,18 +25,23 @@ func NewMemoryRateLimiter() *MemoryRateLimiter {
 	}
 }
 
-// CheckLimit implements RateLimiter. It checks both user and IP sliding windows
-// and increments the counter for the current request.
-func (m *MemoryRateLimiter) CheckLimit(_ context.Context, userID, ipAddress string) (*RateLimitResult, error) {
+// CheckLimit implements RateLimiter against the global default bucket.
+func (m *MemoryRateLimiter) CheckLimit(ctx context.Context, userID, ipAddress string) (*RateLimitResult, error) {
+	return m.CheckLimitWithBucket(ctx, "ratelimit", userID, ipAddress, m.userLimit, m.ipLimit, m.window)
+}
+
+// CheckLimitWithBucket runs the same sliding-window check against a custom
+// bucket namespace and per-call limits/window.
+func (m *MemoryRateLimiter) CheckLimitWithBucket(_ context.Context, bucket, userID, ipAddress string, userLimit, ipLimit int, window time.Duration) (*RateLimitResult, error) {
 	now := time.Now()
-	cutoff := now.Add(-m.window)
-	result := &RateLimitResult{ResetTime: now.Add(m.window)}
+	cutoff := now.Add(-window)
+	result := &RateLimitResult{ResetTime: now.Add(window)}
 
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	if userID != "" {
-		allowed, remaining := m.checkAndAdd("user:"+userID, m.userLimit, cutoff, now)
+		allowed, remaining := m.checkAndAdd(bucket+":user:"+userID, userLimit, cutoff, now)
 		if !allowed {
 			result.Allowed = false
 			result.LimitExceeded = true
@@ -45,7 +50,7 @@ func (m *MemoryRateLimiter) CheckLimit(_ context.Context, userID, ipAddress stri
 		result.Remaining = remaining
 	}
 
-	allowed, remaining := m.checkAndAdd("ip:"+ipAddress, m.ipLimit, cutoff, now)
+	allowed, remaining := m.checkAndAdd(bucket+":ip:"+ipAddress, ipLimit, cutoff, now)
 	if !allowed {
 		result.Allowed = false
 		result.LimitExceeded = true

--- a/backend/internal/service/rate_limiter.go
+++ b/backend/internal/service/rate_limiter.go
@@ -20,6 +20,11 @@ type RateLimitResult struct {
 // RateLimiter interface defines methods for rate limiting
 type RateLimiter interface {
 	CheckLimit(ctx context.Context, userID, ipAddress string) (*RateLimitResult, error)
+	// CheckLimitWithBucket runs the same sliding-window check against a custom
+	// bucket namespace and limit/window pair. Lets a single endpoint enforce
+	// tighter limits than the global default without colliding with the
+	// global ratelimit:user / ratelimit:ip keys.
+	CheckLimitWithBucket(ctx context.Context, bucket, userID, ipAddress string, userLimit, ipLimit int, window time.Duration) (*RateLimitResult, error)
 }
 
 // RedisRateLimiter implements RateLimiter using Redis sliding window
@@ -78,26 +83,33 @@ redis.call('EXPIRE', key, ttl)
 return {1, count + 1}
 `)
 
-// CheckLimit checks both user and IP rate limits using sliding window algorithm
+// CheckLimit checks both user and IP rate limits against the global default
+// bucket using the limiter's configured limits and window.
 func (r *RedisRateLimiter) CheckLimit(ctx context.Context, userID, ipAddress string) (*RateLimitResult, error) {
+	return r.CheckLimitWithBucket(ctx, "ratelimit", userID, ipAddress, r.userLimit, r.ipLimit, r.windowDuration)
+}
+
+// CheckLimitWithBucket runs the sliding-window check against a custom bucket
+// namespace and per-call limits/window. Used by endpoints that need tighter
+// limits than the global default (e.g. /api/research/ask).
+func (r *RedisRateLimiter) CheckLimitWithBucket(ctx context.Context, bucket, userID, ipAddress string, userLimit, ipLimit int, window time.Duration) (*RateLimitResult, error) {
 	now := time.Now()
-	windowStart := now.Add(-r.windowDuration)
+	windowStart := now.Add(-window)
 
 	result := &RateLimitResult{
-		ResetTime: now.Add(r.windowDuration),
+		ResetTime: now.Add(window),
 	}
 
-	// Check user limit if userID is provided
 	if userID != "" {
-		userAllowed, userRemaining, err := r.checkWindowLimit(ctx, "ratelimit:user:"+userID, r.userLimit, windowStart, now)
+		userAllowed, userRemaining, err := r.checkWindowLimitWithTTL(ctx, bucket+":user:"+userID, userLimit, windowStart, now, window)
 		if err != nil {
 			slog.Warn("Redis error checking user rate limit",
+				"bucket", bucket,
 				"user_id", userID,
 				"err", err,
 				"component", "rate_limiter",
 			)
-			// Fail open - allow request if Redis is unavailable
-			return &RateLimitResult{Allowed: true, Remaining: r.userLimit}, nil
+			return &RateLimitResult{Allowed: true, Remaining: userLimit}, nil
 		}
 		if !userAllowed {
 			result.Allowed = false
@@ -108,20 +120,17 @@ func (r *RedisRateLimiter) CheckLimit(ctx context.Context, userID, ipAddress str
 		result.Remaining = userRemaining
 	}
 
-	// Check IP limit
-	ipAllowed, ipRemaining, err := r.checkWindowLimit(ctx, "ratelimit:ip:"+ipAddress, r.ipLimit, windowStart, now)
+	ipAllowed, ipRemaining, err := r.checkWindowLimitWithTTL(ctx, bucket+":ip:"+ipAddress, ipLimit, windowStart, now, window)
 	if err != nil {
 		slog.Warn("Redis error checking IP rate limit",
+			"bucket", bucket,
 			"remote_addr", ipAddress,
 			"err", err,
 			"component", "rate_limiter",
 		)
-		// Fail open: allow but report a generic remaining count.
-		// Use the smaller of the two configured limits as the upper bound — it's
-		// a placeholder header value, not a binding decision.
-		fallback := r.ipLimit
-		if r.userLimit < fallback {
-			fallback = r.userLimit
+		fallback := ipLimit
+		if userLimit < fallback {
+			fallback = userLimit
 		}
 		result.Remaining = fallback
 		result.Allowed = true
@@ -134,9 +143,7 @@ func (r *RedisRateLimiter) CheckLimit(ctx context.Context, userID, ipAddress str
 		return result, nil
 	}
 
-	// Both limits passed
 	result.Allowed = true
-	// Return the more restrictive remaining count
 	if userID != "" && result.Remaining > ipRemaining {
 		result.Remaining = ipRemaining
 	} else if userID == "" {
@@ -146,10 +153,11 @@ func (r *RedisRateLimiter) CheckLimit(ctx context.Context, userID, ipAddress str
 	return result, nil
 }
 
-// checkWindowLimit implements sliding window rate limiting using sorted sets.
-// The check-and-add must be atomic; see slidingWindowScript above.
-func (r *RedisRateLimiter) checkWindowLimit(ctx context.Context, key string, limit int, windowStart, now time.Time) (allowed bool, remaining int, err error) {
-	ttl := int((r.windowDuration + time.Minute) / time.Second)
+// checkWindowLimitWithTTL implements sliding window rate limiting using sorted
+// sets, with the TTL derived from the caller-supplied window. The check-and-add
+// must be atomic; see slidingWindowScript above.
+func (r *RedisRateLimiter) checkWindowLimitWithTTL(ctx context.Context, key string, limit int, windowStart, now time.Time, window time.Duration) (allowed bool, remaining int, err error) {
+	ttl := int((window + time.Minute) / time.Second)
 
 	res, err := slidingWindowScript.Run(ctx, r.client,
 		[]string{key},

--- a/backend/internal/service/rate_limiter_test.go
+++ b/backend/internal/service/rate_limiter_test.go
@@ -121,3 +121,49 @@ func TestMemoryRateLimiter_RemainingDecreases(t *testing.T) {
 		prev = r.Remaining
 	}
 }
+
+func TestMemoryRateLimiter_BucketBlocksAtCustomLimit(t *testing.T) {
+	rl := NewMemoryRateLimiter()
+	ctx := context.Background()
+
+	// User limit (10) is tighter than IP limit (30) — user limit should bind first.
+	for i := 0; i < 10; i++ {
+		r, _ := rl.CheckLimitWithBucket(ctx, "research_ask", "user-1", "10.0.0.1", 10, 30, time.Minute)
+		if !r.Allowed {
+			t.Fatalf("research_ask request %d should be allowed under user limit 10", i+1)
+		}
+	}
+
+	r, _ := rl.CheckLimitWithBucket(ctx, "research_ask", "user-1", "10.0.0.1", 10, 30, time.Minute)
+	if r.Allowed {
+		t.Error("11th request should be blocked by user limit")
+	}
+	if !r.LimitExceeded {
+		t.Error("LimitExceeded should be true")
+	}
+}
+
+func TestMemoryRateLimiter_BucketsAreIsolated(t *testing.T) {
+	rl := NewMemoryRateLimiter()
+	ctx := context.Background()
+
+	// Burn through a tight per-route bucket.
+	for i := 0; i < 5; i++ {
+		rl.CheckLimitWithBucket(ctx, "research_ask", "user-1", "10.0.0.1", 5, 5, time.Minute)
+	}
+	r, _ := rl.CheckLimitWithBucket(ctx, "research_ask", "user-1", "10.0.0.1", 5, 5, time.Minute)
+	if r.Allowed {
+		t.Fatal("research_ask bucket should be exhausted")
+	}
+
+	// Global bucket (default CheckLimit) must NOT be affected — keys are
+	// namespaced by bucket prefix, so the same user/IP can still hit other
+	// endpoints normally.
+	gr, err := rl.CheckLimit(ctx, "user-1", "10.0.0.1")
+	if err != nil {
+		t.Fatalf("CheckLimit: %v", err)
+	}
+	if !gr.Allowed {
+		t.Error("global bucket should be unaffected by exhausted research_ask bucket")
+	}
+}

--- a/backend/internal/service/research/answer.go
+++ b/backend/internal/service/research/answer.go
@@ -1,0 +1,436 @@
+package research
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"papertrader/internal/data"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	answerCacheTTL = time.Hour
+	maxExcerptLen  = 250
+)
+
+var (
+	forwardLookingRe = regexp.MustCompile(
+		`(?i)\b(should|will|would|going to)\b.+\b(buy|sell|hold|invest|outperform|beat|crash|moon|skyrocket)\b`,
+	)
+	forecastTermRe = regexp.MustCompile(
+		`(?i)\b(predict|forecast|next week|next month|next quarter|target price)\b`,
+	)
+	// citationMarkerRe captures the N inside [N] markers in the LLM's answer.
+	// 1-3 digits is enough — we cap retrieval at K=8 by default, and even
+	// generous retrieval bounded by the schema will not exceed 3 digits.
+	citationMarkerRe = regexp.MustCompile(`\[(\d{1,3})\]`)
+)
+
+// retriever is the subset of RetrievalService used by AnswerService.
+// Keeping this an interface lets tests inject a stub without a DB.
+type retriever interface {
+	Retrieve(ctx context.Context, query string, opts RetrieveOpts) ([]data.ChunkHit, error)
+}
+
+// queriesStore is the subset of data.ResearchQueriesStore used by AnswerService.
+type queriesStore interface {
+	Insert(ctx context.Context, q data.ResearchQuery) error
+}
+
+// AnswerService orchestrates retrieval, LLM generation, and citation validation.
+type AnswerService struct {
+	retrieval   retriever
+	llm         LLMClient
+	queries     queriesStore
+	answerCache *redis.Client // optional, nil-safe
+}
+
+func NewAnswerService(
+	ret retriever,
+	llm LLMClient,
+	queries queriesStore,
+	cache *redis.Client,
+) *AnswerService {
+	return &AnswerService{
+		retrieval:   ret,
+		llm:         llm,
+		queries:     queries,
+		answerCache: cache,
+	}
+}
+
+// Citation is one source that the LLM cited in its answer.
+type Citation struct {
+	ChunkID   string  `json:"chunk_id"`
+	SourceURL string  `json:"source_url"`
+	Symbol    string  `json:"symbol,omitempty"`
+	FiledAt   string  `json:"filed_at,omitempty"`
+	Excerpt   string  `json:"excerpt"`
+	Score     float64 `json:"score"`
+}
+
+// Answer is the top-level response type returned from Ask.
+type Answer struct {
+	QueryID       string     `json:"query_id"`
+	Answer        string     `json:"answer"`
+	Citations     []Citation `json:"citations"`
+	Refused       bool       `json:"refused"`
+	RefusalReason string     `json:"refusal_reason,omitempty"`
+	LatencyMS     int        `json:"latency_ms"`
+}
+
+// AskOpts parameterises a single Ask call.
+type AskOpts struct {
+	Symbols  []string
+	K        int
+	MinScore float64
+}
+
+func (s *AnswerService) Ask(ctx context.Context, userID, query string, opts AskOpts) (*Answer, error) {
+	start := time.Now()
+
+	k := opts.K
+	if k <= 0 {
+		k = 8
+	}
+	minScore := opts.MinScore
+	if minScore <= 0 {
+		// Tuned for voyage-finance-2: genuine matches on financial text
+		// cluster in 0.40-0.50, not 0.55+. Higher floors over-refuse.
+		minScore = 0.40
+	}
+
+	queryID := makeQueryID(query, userID, start)
+
+	// 1. Answer cache lookup.
+	cacheKey := answerCacheKey(query, opts.Symbols)
+	if s.answerCache != nil {
+		if cached, err := s.answerCache.Get(ctx, cacheKey).Bytes(); err == nil {
+			var a Answer
+			if jsonErr := json.Unmarshal(cached, &a); jsonErr == nil {
+				a.QueryID = queryID
+				return &a, nil
+			}
+		}
+	}
+
+	// 2. Forward-looking refusal (no retrieval, no LLM).
+	if isForwardLooking(query) {
+		return s.refuse(ctx, queryID, userID, query, "forward_looking", start, nil)
+	}
+
+	// 3. Retrieve.
+	retrieveStart := time.Now()
+	hits, err := s.retrieval.Retrieve(ctx, query, RetrieveOpts{
+		Symbols:  opts.Symbols,
+		K:        k,
+		MinScore: minScore,
+	})
+	if err != nil {
+		slog.Error("research retrieval failed", "query_id", queryID, "err", err)
+		return nil, err
+	}
+	retrievalMS := int(time.Since(retrieveStart).Milliseconds())
+
+	// 4. No sources or top score too low.
+	if len(hits) == 0 || hits[0].Score < minScore {
+		return s.refuse(ctx, queryID, userID, query, "no_sources", start, intPtr(retrievalMS))
+	}
+
+	// 5. Build prompt.
+	systemPrompt, userPrompt := buildPrompt(hits, query)
+
+	// 6. Call LLM.
+	genStart := time.Now()
+	result, err := s.llm.Generate(ctx, systemPrompt, userPrompt, LLMOpts{
+		Temperature: 0.1,
+		MaxTokens:   800,
+		JSONMode:    true,
+	})
+	if err != nil {
+		slog.Error("research LLM call failed", "query_id", queryID, "err", err)
+		return nil, err
+	}
+	generationMS := int(time.Since(genStart).Milliseconds())
+
+	content := strings.TrimSpace(result.Content)
+
+	// Sentinels: LLM may return these as raw strings even in JSON mode.
+	switch content {
+	case "OUT_OF_SCOPE":
+		return s.refuseWithTokens(ctx, queryID, userID, query, "out_of_scope", start,
+			intPtr(retrievalMS), intPtr(generationMS), result.PromptTokens, result.CompletionTokens)
+	case "INSUFFICIENT_SOURCES":
+		return s.refuseWithTokens(ctx, queryID, userID, query, "no_sources", start,
+			intPtr(retrievalMS), intPtr(generationMS), result.PromptTokens, result.CompletionTokens)
+	}
+
+	// Parse structured response.
+	var llmOut struct {
+		Answer      string   `json:"answer"`
+		UsedChunkIDs []string `json:"used_chunk_ids"`
+	}
+	if err := json.Unmarshal([]byte(content), &llmOut); err != nil {
+		slog.Warn("research LLM returned invalid JSON",
+			"query_id", queryID, "content_prefix", truncate(content, 120))
+		return s.refuseWithTokens(ctx, queryID, userID, query, "model_error", start,
+			intPtr(retrievalMS), intPtr(generationMS), result.PromptTokens, result.CompletionTokens)
+	}
+	if llmOut.Answer == "" {
+		slog.Warn("research LLM JSON missing answer field", "query_id", queryID)
+		return s.refuseWithTokens(ctx, queryID, userID, query, "model_error", start,
+			intPtr(retrievalMS), intPtr(generationMS), result.PromptTokens, result.CompletionTokens)
+	}
+
+	// 7. Validate citations.
+	hitByID := make(map[string]data.ChunkHit, len(hits))
+	for _, h := range hits {
+		hitByID[h.ChunkID] = h
+	}
+	var badIDs []string
+	for _, id := range llmOut.UsedChunkIDs {
+		if _, ok := hitByID[id]; !ok {
+			badIDs = append(badIDs, id)
+		}
+	}
+	if len(badIDs) > 0 {
+		slog.Warn("research LLM cited unknown chunk IDs",
+			"query_id", queryID, "bad_ids", badIDs)
+		return s.refuseWithTokens(ctx, queryID, userID, query, "hallucinated_citation", start,
+			intPtr(retrievalMS), intPtr(generationMS), result.PromptTokens, result.CompletionTokens)
+	}
+
+	// 7b. Validate that every [N] marker in the answer text maps to a chunk
+	// that is also in used_chunk_ids. Without this check the model can write
+	// "revenue was X [5]" while used_chunk_ids contains an unrelated chunk —
+	// the citation appears valid (chunk exists in retrieval) but does not
+	// match the marker, defeating the whole point of citations.
+	usedSet := make(map[string]bool, len(llmOut.UsedChunkIDs))
+	for _, id := range llmOut.UsedChunkIDs {
+		usedSet[id] = true
+	}
+	var badMarkers []string
+	for _, m := range citationMarkerRe.FindAllStringSubmatch(llmOut.Answer, -1) {
+		n, err := strconv.Atoi(m[1])
+		if err != nil || n < 1 || n > len(hits) {
+			badMarkers = append(badMarkers, m[0])
+			continue
+		}
+		if !usedSet[hits[n-1].ChunkID] {
+			badMarkers = append(badMarkers, m[0])
+		}
+	}
+	if len(badMarkers) > 0 {
+		// Cap logging to first 5 to avoid log-spam from a malicious model
+		// that emits hundreds of bad markers.
+		if len(badMarkers) > 5 {
+			badMarkers = badMarkers[:5]
+		}
+		slog.Warn("research LLM emitted citation markers not in used_chunk_ids",
+			"query_id", queryID, "bad_markers", badMarkers)
+		return s.refuseWithTokens(ctx, queryID, userID, query, "hallucinated_citation", start,
+			intPtr(retrievalMS), intPtr(generationMS), result.PromptTokens, result.CompletionTokens)
+	}
+
+	// 8. Build citations (in LLM citation order, deduped).
+	seen := make(map[string]bool, len(llmOut.UsedChunkIDs))
+	var citations []Citation
+	for _, id := range llmOut.UsedChunkIDs {
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		h := hitByID[id]
+		c := Citation{
+			ChunkID:   h.ChunkID,
+			SourceURL: h.SourceURL,
+			Symbol:    h.Symbol,
+			Excerpt:   truncate(h.Text, maxExcerptLen),
+			Score:     h.Score,
+		}
+		if h.FiledAt != nil {
+			c.FiledAt = h.FiledAt.Format("2006-01-02")
+		}
+		citations = append(citations, c)
+	}
+
+	// 9. Persist.
+	totalMS := int(time.Since(start).Milliseconds())
+	costMicros := CalcCostMicros(s.llm, result.PromptTokens, result.CompletionTokens)
+	model := s.llm.Model()
+	citationsJSON, _ := json.Marshal(citations)
+
+	answerText := llmOut.Answer
+	_ = s.queries.Insert(ctx, data.ResearchQuery{
+		ID:               queryID,
+		UserID:           nilIfEmpty(userID),
+		QueryText:        query,
+		AnswerText:       &answerText,
+		Refused:          false,
+		Citations:        citationsJSON,
+		RetrievalMS:      intPtr(retrievalMS),
+		GenerationMS:     intPtr(generationMS),
+		TotalMS:          intPtr(totalMS),
+		PromptTokens:     intPtr(result.PromptTokens),
+		CompletionTokens: intPtr(result.CompletionTokens),
+		CostUSDMicros:    intPtr(costMicros),
+		Model:            &model,
+	})
+
+	answer := &Answer{
+		QueryID:   queryID,
+		Answer:    llmOut.Answer,
+		Citations: citations,
+		Refused:   false,
+		LatencyMS: totalMS,
+	}
+
+	// 10. Cache.
+	if s.answerCache != nil {
+		if b, err := json.Marshal(answer); err == nil {
+			_ = s.answerCache.Set(ctx, cacheKey, b, answerCacheTTL).Err()
+		}
+	}
+
+	return answer, nil
+}
+
+// refuse builds a refusal Answer with no token data and persists it.
+func (s *AnswerService) refuse(
+	ctx context.Context,
+	queryID, userID, query, reason string,
+	start time.Time,
+	retrievalMS *int,
+) (*Answer, error) {
+	return s.refuseWithTokens(ctx, queryID, userID, query, reason, start, retrievalMS, nil, 0, 0)
+}
+
+func (s *AnswerService) refuseWithTokens(
+	ctx context.Context,
+	queryID, userID, query, reason string,
+	start time.Time,
+	retrievalMS, generationMS *int,
+	promptTokens, completionTokens int,
+) (*Answer, error) {
+	totalMS := int(time.Since(start).Milliseconds())
+
+	row := data.ResearchQuery{
+		ID:           queryID,
+		UserID:       nilIfEmpty(userID),
+		QueryText:    query,
+		Refused:      true,
+		RefusalReason: stringPtr(reason),
+		Citations:    []byte("[]"),
+		RetrievalMS:  retrievalMS,
+		GenerationMS: generationMS,
+		TotalMS:      intPtr(totalMS),
+	}
+	if promptTokens > 0 {
+		row.PromptTokens = intPtr(promptTokens)
+	}
+	if completionTokens > 0 {
+		row.CompletionTokens = intPtr(completionTokens)
+	}
+	if promptTokens > 0 || completionTokens > 0 {
+		cost := CalcCostMicros(s.llm, promptTokens, completionTokens)
+		row.CostUSDMicros = intPtr(cost)
+		model := s.llm.Model()
+		row.Model = &model
+	}
+
+	_ = s.queries.Insert(ctx, row)
+
+	return &Answer{
+		QueryID:       queryID,
+		Refused:       true,
+		RefusalReason: reason,
+		Citations:     []Citation{},
+		LatencyMS:     totalMS,
+	}, nil
+}
+
+func isForwardLooking(query string) bool {
+	return forwardLookingRe.MatchString(query) || forecastTermRe.MatchString(query)
+}
+
+// buildPrompt constructs the system and user prompt strings from the retrieved hits.
+func buildPrompt(hits []data.ChunkHit, query string) (system, user string) {
+	system = `You are a financial research assistant. Answer ONLY using the numbered sources below.
+- If the sources do not contain enough information to answer, reply EXACTLY: INSUFFICIENT_SOURCES
+- Do not give buy/sell/hold recommendations or price predictions. If the user asks for one, reply EXACTLY: OUT_OF_SCOPE
+- Never speculate. Never use information outside the sources.
+
+Citation discipline (read carefully — this is graded):
+- Cite each factual claim with [N] markers pointing to the numbered sources.
+- Each [N] must point to a chunk that, on its own, directly substantiates the specific claim being made.
+- Do NOT cite a chunk just because it is topically related. Topical relevance is not support.
+- Prefer ONE citation per claim. Only add a second [N] when a second source independently supports the same specific claim.
+- When in doubt, cite less, not more. An uncited sentence is better than a wrong citation.
+- Do not bundle citations like [1][2][3][4][5] for one sentence — that is a hallucinated-citation failure.
+
+Output format (JSON only, no other text):
+{"answer": "<your answer with [1], [2], ... markers>", "used_chunk_ids": ["chunk_id_1", "chunk_id_2"]}`
+
+	var sb strings.Builder
+	sb.WriteString("SOURCES:\n")
+	for i, h := range hits {
+		sb.WriteString(fmt.Sprintf("[%d] (chunk_id: %s", i+1, h.ChunkID))
+		if h.Symbol != "" {
+			sb.WriteString(fmt.Sprintf(", %s", h.Symbol))
+		}
+		if h.FiledAt != nil {
+			sb.WriteString(fmt.Sprintf(" filed %s", h.FiledAt.Format("2006-01-02")))
+		}
+		if h.Section != "" {
+			sb.WriteString(fmt.Sprintf(`, section "%s"`, h.Section))
+		}
+		sb.WriteString(")\n")
+		sb.WriteString(h.Text)
+		sb.WriteString("\n\n")
+	}
+	sb.WriteString("QUESTION: ")
+	sb.WriteString(query)
+	user = sb.String()
+	return
+}
+
+func answerCacheKey(query string, symbols []string) string {
+	normalized := strings.ToLower(strings.TrimSpace(query))
+	joined := strings.Join(symbols, ",")
+	sum := sha256.Sum256([]byte(normalized + joined))
+	return fmt.Sprintf("research:answer:%x", sum)
+}
+
+func makeQueryID(query, userID string, t time.Time) string {
+	raw := fmt.Sprintf("%s|%s|%d", query, userID, t.UnixNano())
+	sum := sha256.Sum256([]byte(raw))
+	return fmt.Sprintf("%x", sum[:16])
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}
+
+func stringPtr(s string) *string { return &s }
+func intPtr(n int) *int          { return &n }
+
+// nilIfEmpty returns nil when s is the empty string so that optional FK columns
+// (e.g. research_queries.user_id) are written as SQL NULL rather than a FK
+// violation when no real user is associated with the query.
+func nilIfEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}

--- a/backend/internal/service/research/answer_test.go
+++ b/backend/internal/service/research/answer_test.go
@@ -1,0 +1,257 @@
+package research
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"papertrader/internal/data"
+)
+
+// ---- stubs ----
+
+type stubRetriever struct {
+	hits    []data.ChunkHit
+	err     error
+	called  int
+}
+
+func (s *stubRetriever) Retrieve(_ context.Context, _ string, _ RetrieveOpts) ([]data.ChunkHit, error) {
+	s.called++
+	return s.hits, s.err
+}
+
+type stubLLM struct {
+	result LLMResult
+	err    error
+}
+
+func (s *stubLLM) Generate(_ context.Context, _, _ string, _ LLMOpts) (LLMResult, error) {
+	return s.result, s.err
+}
+func (s *stubLLM) Model() string                        { return "stub-llm" }
+func (s *stubLLM) PriceMicrosPer1KTokens() (int, int) { return 59, 79 }
+
+type capturedQuery struct {
+	q data.ResearchQuery
+}
+
+type stubQueriesStore struct {
+	inserts []capturedQuery
+}
+
+func (s *stubQueriesStore) Insert(_ context.Context, q data.ResearchQuery) error {
+	s.inserts = append(s.inserts, capturedQuery{q: q})
+	return nil
+}
+
+// ---- helpers ----
+
+func makeHits(n int, score float64) []data.ChunkHit {
+	t := time.Now()
+	hits := make([]data.ChunkHit, n)
+	for i := range hits {
+		hits[i] = data.ChunkHit{
+			ChunkID:   fmt.Sprintf("chunk-%d", i+1),
+			DocumentID: fmt.Sprintf("doc-%d", i+1),
+			Text:      "some source text about financials",
+			SourceURL: "https://example.com/filing",
+			Symbol:    "AAPL",
+			FiledAt:   &t,
+			Score:     score,
+		}
+	}
+	return hits
+}
+
+func newAnswerSvc(ret retriever, llm LLMClient, qs queriesStore) *AnswerService {
+	return NewAnswerService(ret, llm, qs, nil)
+}
+
+// ---- tests ----
+
+func TestAsk_Refuses_NoSources(t *testing.T) {
+	ret := &stubRetriever{hits: []data.ChunkHit{}}
+	qs := &stubQueriesStore{}
+	svc := newAnswerSvc(ret, &stubLLM{}, qs)
+
+	answer, err := svc.Ask(context.Background(), "user1", "What is AAPL revenue?", AskOpts{})
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if !answer.Refused {
+		t.Error("expected Refused=true")
+	}
+	if answer.RefusalReason != "no_sources" {
+		t.Errorf("RefusalReason = %q, want %q", answer.RefusalReason, "no_sources")
+	}
+	if len(qs.inserts) != 1 {
+		t.Fatalf("expected 1 inserted row, got %d", len(qs.inserts))
+	}
+	if !qs.inserts[0].q.Refused {
+		t.Error("persisted row should have Refused=true")
+	}
+}
+
+func TestAsk_Refuses_LowScore(t *testing.T) {
+	ret := &stubRetriever{hits: makeHits(2, 0.30)} // all below default minScore 0.55
+	qs := &stubQueriesStore{}
+	svc := newAnswerSvc(ret, &stubLLM{}, qs)
+
+	answer, err := svc.Ask(context.Background(), "user1", "What is AAPL revenue?", AskOpts{MinScore: 0.55})
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if !answer.Refused {
+		t.Error("expected Refused=true for low-score hits")
+	}
+	if answer.RefusalReason != "no_sources" {
+		t.Errorf("RefusalReason = %q, want %q", answer.RefusalReason, "no_sources")
+	}
+	if len(qs.inserts) != 1 {
+		t.Fatalf("expected 1 inserted row, got %d", len(qs.inserts))
+	}
+}
+
+func TestAsk_Refuses_ForwardLooking(t *testing.T) {
+	ret := &stubRetriever{}
+	qs := &stubQueriesStore{}
+	svc := newAnswerSvc(ret, &stubLLM{}, qs)
+
+	answer, err := svc.Ask(context.Background(), "user1", "should I buy NVDA next week", AskOpts{})
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if !answer.Refused {
+		t.Error("expected Refused=true for forward-looking query")
+	}
+	if answer.RefusalReason != "forward_looking" {
+		t.Errorf("RefusalReason = %q, want %q", answer.RefusalReason, "forward_looking")
+	}
+	if ret.called != 0 {
+		t.Errorf("retriever should NOT be called for forward-looking queries, called %d times", ret.called)
+	}
+	if len(qs.inserts) != 1 {
+		t.Fatalf("expected 1 persisted row, got %d", len(qs.inserts))
+	}
+}
+
+func TestAsk_Refuses_OutOfScope(t *testing.T) {
+	hits := makeHits(2, 0.80)
+	ret := &stubRetriever{hits: hits}
+	qs := &stubQueriesStore{}
+	llm := &stubLLM{result: LLMResult{Content: "OUT_OF_SCOPE", PromptTokens: 50, CompletionTokens: 1}}
+	svc := newAnswerSvc(ret, llm, qs)
+
+	answer, err := svc.Ask(context.Background(), "user1", "What is AAPL gross margin?", AskOpts{})
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if !answer.Refused {
+		t.Error("expected Refused=true for OUT_OF_SCOPE")
+	}
+	if answer.RefusalReason != "out_of_scope" {
+		t.Errorf("RefusalReason = %q, want %q", answer.RefusalReason, "out_of_scope")
+	}
+}
+
+func TestAsk_Refuses_InsufficientSources(t *testing.T) {
+	hits := makeHits(2, 0.80)
+	ret := &stubRetriever{hits: hits}
+	qs := &stubQueriesStore{}
+	llm := &stubLLM{result: LLMResult{Content: "INSUFFICIENT_SOURCES", PromptTokens: 50, CompletionTokens: 1}}
+	svc := newAnswerSvc(ret, llm, qs)
+
+	answer, err := svc.Ask(context.Background(), "user1", "What were AAPL's 2030 earnings?", AskOpts{})
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if !answer.Refused {
+		t.Error("expected Refused=true for INSUFFICIENT_SOURCES")
+	}
+	if answer.RefusalReason != "no_sources" {
+		t.Errorf("RefusalReason = %q, want %q", answer.RefusalReason, "no_sources")
+	}
+}
+
+func TestAsk_Refuses_HallucinatedCitation(t *testing.T) {
+	hits := makeHits(2, 0.80)
+	ret := &stubRetriever{hits: hits}
+	qs := &stubQueriesStore{}
+
+	badID := "chunk-999"
+	llmJSON := `{"answer":"revenue was X [1]","used_chunk_ids":["` + badID + `"]}`
+	llm := &stubLLM{result: LLMResult{Content: llmJSON, PromptTokens: 50, CompletionTokens: 20}}
+	svc := newAnswerSvc(ret, llm, qs)
+
+	answer, err := svc.Ask(context.Background(), "user1", "What is AAPL revenue?", AskOpts{})
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if !answer.Refused {
+		t.Error("expected Refused=true for hallucinated citation")
+	}
+	if answer.RefusalReason != "hallucinated_citation" {
+		t.Errorf("RefusalReason = %q, want %q", answer.RefusalReason, "hallucinated_citation")
+	}
+}
+
+func TestAsk_Refuses_ModelError(t *testing.T) {
+	hits := makeHits(2, 0.80)
+	ret := &stubRetriever{hits: hits}
+	qs := &stubQueriesStore{}
+	llm := &stubLLM{result: LLMResult{Content: "not valid json at all", PromptTokens: 40, CompletionTokens: 5}}
+	svc := newAnswerSvc(ret, llm, qs)
+
+	answer, err := svc.Ask(context.Background(), "user1", "What is AAPL revenue?", AskOpts{})
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if !answer.Refused {
+		t.Error("expected Refused=true for invalid JSON from model")
+	}
+	if answer.RefusalReason != "model_error" {
+		t.Errorf("RefusalReason = %q, want %q", answer.RefusalReason, "model_error")
+	}
+}
+
+func TestAsk_HappyPath(t *testing.T) {
+	hits := makeHits(3, 0.85)
+	ret := &stubRetriever{hits: hits}
+	qs := &stubQueriesStore{}
+
+	usedIDs := []string{hits[0].ChunkID, hits[1].ChunkID, hits[2].ChunkID}
+	usedIDsJSON, _ := json.Marshal(usedIDs)
+	llmJSON := `{"answer":"revenue was $X [1][2][3]","used_chunk_ids":` + string(usedIDsJSON) + `}`
+	llm := &stubLLM{result: LLMResult{Content: llmJSON, PromptTokens: 200, CompletionTokens: 50}}
+	svc := newAnswerSvc(ret, llm, qs)
+
+	answer, err := svc.Ask(context.Background(), "user1", "What is AAPL revenue?", AskOpts{})
+	if err != nil {
+		t.Fatalf("Ask: %v", err)
+	}
+	if answer.Refused {
+		t.Errorf("expected Refused=false, got RefusalReason=%q", answer.RefusalReason)
+	}
+	if len(answer.Citations) != 3 {
+		t.Errorf("expected 3 citations, got %d", len(answer.Citations))
+	}
+	if answer.LatencyMS < 0 {
+		t.Error("expected LatencyMS >= 0")
+	}
+	if len(qs.inserts) != 1 {
+		t.Fatalf("expected 1 persisted row, got %d", len(qs.inserts))
+	}
+	row := qs.inserts[0].q
+	if row.PromptTokens == nil || *row.PromptTokens != 200 {
+		t.Error("PromptTokens not persisted correctly")
+	}
+	if row.CompletionTokens == nil || *row.CompletionTokens != 50 {
+		t.Error("CompletionTokens not persisted correctly")
+	}
+	if row.CostUSDMicros == nil || *row.CostUSDMicros <= 0 {
+		t.Error("cost_usd_micros should be positive")
+	}
+}

--- a/backend/internal/service/research/embed.go
+++ b/backend/internal/service/research/embed.go
@@ -1,0 +1,165 @@
+package research
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/gob"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// Embedder embeds text into fixed-dimension float32 vectors.
+type Embedder interface {
+	EmbedQuery(ctx context.Context, text string) ([]float32, int, error)
+	EmbedBatch(ctx context.Context, texts []string) ([][]float32, int, error)
+	Model() string
+}
+
+// VoyageEmbedder calls the Voyage AI embeddings API (voyage-finance-2).
+type VoyageEmbedder struct {
+	httpClient *http.Client
+	apiKey     string
+	model      string
+}
+
+func NewVoyageEmbedder(apiKey string) *VoyageEmbedder {
+	return &VoyageEmbedder{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		apiKey:     apiKey,
+		model:      "voyage-finance-2",
+	}
+}
+
+func (v *VoyageEmbedder) Model() string { return "voyage-finance-2" }
+
+func (v *VoyageEmbedder) EmbedQuery(ctx context.Context, text string) ([]float32, int, error) {
+	vecs, tokens, err := v.callAPI(ctx, []string{text}, "query")
+	if err != nil {
+		return nil, 0, err
+	}
+	if len(vecs) == 0 {
+		return nil, 0, fmt.Errorf("voyage embed: empty response")
+	}
+	return vecs[0], tokens, nil
+}
+
+func (v *VoyageEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, int, error) {
+	if len(texts) == 0 {
+		return nil, 0, nil
+	}
+	return v.callAPI(ctx, texts, "document")
+}
+
+func (v *VoyageEmbedder) callAPI(ctx context.Context, inputs []string, inputType string) ([][]float32, int, error) {
+	payload, err := json.Marshal(map[string]any{
+		"input":      inputs,
+		"model":      v.model,
+		"input_type": inputType,
+	})
+	if err != nil {
+		return nil, 0, fmt.Errorf("voyage embed: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		"https://api.voyageai.com/v1/embeddings",
+		bytes.NewReader(payload))
+	if err != nil {
+		return nil, 0, fmt.Errorf("voyage embed: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+v.apiKey)
+
+	resp, err := v.httpClient.Do(req)
+	if err != nil {
+		return nil, 0, fmt.Errorf("voyage embed: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		// Read a bounded body for context; never log headers or the request body.
+		limited, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, 0, fmt.Errorf("voyage embed: status %d: %s", resp.StatusCode, limited)
+	}
+
+	var result struct {
+		Data []struct {
+			Embedding []float32 `json:"embedding"`
+			Index     int       `json:"index"`
+		} `json:"data"`
+		Usage struct {
+			TotalTokens int `json:"total_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, 0, fmt.Errorf("voyage embed: decode response: %w", err)
+	}
+
+	vecs := make([][]float32, len(result.Data))
+	for _, d := range result.Data {
+		if d.Index < 0 || d.Index >= len(vecs) {
+			return nil, 0, fmt.Errorf("voyage embed: index %d out of range for %d inputs", d.Index, len(inputs))
+		}
+		vecs[d.Index] = d.Embedding
+	}
+	return vecs, result.Usage.TotalTokens, nil
+}
+
+// CachedEmbedder wraps an Embedder with a Redis-backed embedding cache.
+// If redis is nil, it delegates directly to the underlying embedder.
+// Cache key: embed:v3:sha256(text). Only EmbedQuery is cached;
+// batch calls bypass the cache to keep things simple.
+type CachedEmbedder struct {
+	inner Embedder
+	redis *redis.Client
+}
+
+const embedCacheTTL = 7 * 24 * time.Hour
+
+func NewCachedEmbedder(inner Embedder, redisClient *redis.Client) *CachedEmbedder {
+	return &CachedEmbedder{inner: inner, redis: redisClient}
+}
+
+func (c *CachedEmbedder) Model() string { return c.inner.Model() }
+
+func (c *CachedEmbedder) EmbedQuery(ctx context.Context, text string) ([]float32, int, error) {
+	if c.redis == nil {
+		return c.inner.EmbedQuery(ctx, text)
+	}
+
+	key := embedCacheKey(text)
+
+	if cached, err := c.redis.Get(ctx, key).Bytes(); err == nil {
+		var vec []float32
+		if err := gob.NewDecoder(bytes.NewReader(cached)).Decode(&vec); err == nil {
+			return vec, len(text) / 4, nil
+		}
+	}
+
+	vec, tokens, err := c.inner.EmbedQuery(ctx, text)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(vec); err == nil {
+		// Best-effort write; ignore cache errors.
+		_ = c.redis.Set(ctx, key, buf.Bytes(), embedCacheTTL).Err()
+	}
+
+	return vec, tokens, nil
+}
+
+func (c *CachedEmbedder) EmbedBatch(ctx context.Context, texts []string) ([][]float32, int, error) {
+	return c.inner.EmbedBatch(ctx, texts)
+}
+
+func embedCacheKey(text string) string {
+	sum := sha256.Sum256([]byte(text))
+	return fmt.Sprintf("embed:v3:%x", sum)
+}

--- a/backend/internal/service/research/embed_test.go
+++ b/backend/internal/service/research/embed_test.go
@@ -1,0 +1,193 @@
+package research
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func voyageResponse(t *testing.T, n int) []byte {
+	t.Helper()
+	type embedding struct {
+		Object    string    `json:"object"`
+		Embedding []float32 `json:"embedding"`
+		Index     int       `json:"index"`
+	}
+	type usage struct {
+		TotalTokens int `json:"total_tokens"`
+	}
+	type response struct {
+		Object string      `json:"object"`
+		Data   []embedding `json:"data"`
+		Model  string      `json:"model"`
+		Usage  usage       `json:"usage"`
+	}
+
+	data := make([]embedding, n)
+	for i := range data {
+		vec := make([]float32, 1024)
+		vec[i%1024] = 1.0
+		data[i] = embedding{Object: "embedding", Embedding: vec, Index: i}
+	}
+	b, err := json.Marshal(response{
+		Object: "list",
+		Data:   data,
+		Model:  "voyage-finance-2",
+		Usage:  usage{TotalTokens: n * 10},
+	})
+	if err != nil {
+		t.Fatalf("marshal voyage response: %v", err)
+	}
+	return b
+}
+
+func TestVoyageEmbedder_EmbedQuery_AuthHeader(t *testing.T) {
+	const apiKey = "test-key-abc"
+	var gotAuth string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(voyageResponse(t, 1))
+	}))
+	defer srv.Close()
+
+	e := &VoyageEmbedder{
+		httpClient: srv.Client(),
+		apiKey:     apiKey,
+		model:      "voyage-finance-2",
+	}
+	// Point at the test server by temporarily replacing the URL via the client transport.
+	// We reach into callAPI via EmbedQuery; override the endpoint by wrapping the transport
+	// so requests to voyageai.com are redirected to the test server.
+	e.httpClient = &http.Client{
+		Transport: redirectTransport(srv.URL),
+	}
+
+	_, _, err := e.EmbedQuery(context.Background(), "hello")
+	if err != nil {
+		t.Fatalf("EmbedQuery: %v", err)
+	}
+	if gotAuth != "Bearer "+apiKey {
+		t.Errorf("Authorization header = %q, want %q", gotAuth, "Bearer "+apiKey)
+	}
+}
+
+func TestVoyageEmbedder_EmbedQuery_InputType(t *testing.T) {
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(voyageResponse(t, 1))
+	}))
+	defer srv.Close()
+
+	e := &VoyageEmbedder{
+		httpClient: &http.Client{Transport: redirectTransport(srv.URL)},
+		apiKey:     "k",
+		model:      "voyage-finance-2",
+	}
+
+	if _, _, err := e.EmbedQuery(context.Background(), "query text"); err != nil {
+		t.Fatalf("EmbedQuery: %v", err)
+	}
+	if gotBody["input_type"] != "query" {
+		t.Errorf("EmbedQuery input_type = %v, want %q", gotBody["input_type"], "query")
+	}
+	if gotBody["model"] != "voyage-finance-2" {
+		t.Errorf("EmbedQuery model = %v, want %q", gotBody["model"], "voyage-finance-2")
+	}
+}
+
+func TestVoyageEmbedder_EmbedBatch_InputType(t *testing.T) {
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(voyageResponse(t, 2))
+	}))
+	defer srv.Close()
+
+	e := &VoyageEmbedder{
+		httpClient: &http.Client{Transport: redirectTransport(srv.URL)},
+		apiKey:     "k",
+		model:      "voyage-finance-2",
+	}
+
+	if _, _, err := e.EmbedBatch(context.Background(), []string{"doc one", "doc two"}); err != nil {
+		t.Fatalf("EmbedBatch: %v", err)
+	}
+	if gotBody["input_type"] != "document" {
+		t.Errorf("EmbedBatch input_type = %v, want %q", gotBody["input_type"], "document")
+	}
+}
+
+func TestVoyageEmbedder_URLDoesNotContainKey(t *testing.T) {
+	const apiKey = "secret-voyage-key"
+	var gotURL string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(voyageResponse(t, 1))
+	}))
+	defer srv.Close()
+
+	e := &VoyageEmbedder{
+		httpClient: &http.Client{Transport: redirectTransport(srv.URL)},
+		apiKey:     apiKey,
+		model:      "voyage-finance-2",
+	}
+
+	if _, _, err := e.EmbedQuery(context.Background(), "test"); err != nil {
+		t.Fatalf("EmbedQuery: %v", err)
+	}
+	if strings.Contains(gotURL, apiKey) {
+		t.Errorf("request URL contains API key: %q", gotURL)
+	}
+}
+
+func TestVoyageEmbedder_ErrorDoesNotLeakKey(t *testing.T) {
+	const apiKey = "super-secret-key"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	e := &VoyageEmbedder{
+		httpClient: &http.Client{Transport: redirectTransport(srv.URL)},
+		apiKey:     apiKey,
+		model:      "voyage-finance-2",
+	}
+
+	_, _, err := e.EmbedQuery(context.Background(), "test")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if strings.Contains(err.Error(), apiKey) {
+		t.Errorf("error message contains API key: %v", err)
+	}
+}
+
+// redirectTransport rewrites every request's host to the given base URL so
+// the real voyageai.com hostname is never contacted during tests.
+type redirectTransport string
+
+func (base redirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req2 := req.Clone(req.Context())
+	req2.URL.Scheme = "http"
+	req2.URL.Host = strings.TrimPrefix(string(base), "http://")
+	return http.DefaultTransport.RoundTrip(req2)
+}

--- a/backend/internal/service/research/ingest/chunk.go
+++ b/backend/internal/service/research/ingest/chunk.go
@@ -1,0 +1,145 @@
+package ingest
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Chunk is a text fragment produced by ChunkText.
+type Chunk struct {
+	Index      int
+	Text       string
+	TokenCount int
+	Section    string
+}
+
+// ChunkOpts controls the chunking strategy.
+type ChunkOpts struct {
+	TargetTokens  int
+	OverlapTokens int
+}
+
+// approxTokens estimates the token count of s using the heuristic len/4,
+// which matches English text closely enough for budgeting purposes.
+func approxTokens(s string) int {
+	return len(s) / 4
+}
+
+// sectionHeaderRe matches common 10-K section headers such as
+// "Item 1A.", "Item 7.", "Item 15.", "ITEM 1A.", etc.
+var sectionHeaderRe = regexp.MustCompile(`(?i)^\s*(Item\s+\d+[A-Za-z]?\.?)`)
+
+// ChunkText splits text into overlapping chunks of approximately TargetTokens.
+// Strategy:
+//  1. Split on paragraph boundaries ("\n\n").
+//  2. If a paragraph exceeds TargetTokens, fall back to sentence splitting (". ").
+//  3. Greedy-pack segments into chunks up to TargetTokens.
+//  4. Carry OverlapTokens of trailing text into the next chunk.
+//  5. Track the most-recently-seen section header and attach it to chunks.
+func ChunkText(text string, opts ChunkOpts) []Chunk {
+	if opts.TargetTokens <= 0 {
+		opts.TargetTokens = 500
+	}
+	if opts.OverlapTokens <= 0 {
+		opts.OverlapTokens = 80
+	}
+
+	paragraphs := strings.Split(text, "\n\n")
+	// Flatten into segments ≤ TargetTokens each.
+	var segments []string
+	for _, para := range paragraphs {
+		para = strings.TrimSpace(para)
+		if para == "" {
+			continue
+		}
+		if approxTokens(para) <= opts.TargetTokens {
+			segments = append(segments, para)
+		} else {
+			// Fall back to sentence split.
+			sentences := strings.SplitAfter(para, ". ")
+			for _, s := range sentences {
+				s = strings.TrimSpace(s)
+				if s != "" {
+					segments = append(segments, s)
+				}
+			}
+		}
+	}
+
+	var chunks []Chunk
+	var current strings.Builder
+	currentTokens := 0
+	// chunkSection tracks the section that was in force when the current chunk
+	// started accumulating. It is snapshotted at the start of each chunk so
+	// that a section header encountered mid-accumulation doesn't retroactively
+	// relabel the already-buffered text.
+	chunkSection := ""
+	// latestSection is the most recently seen section header across all segments.
+	latestSection := ""
+	chunkIndex := 0
+	var overlapTail string // text carried from the previous chunk
+
+	flush := func() {
+		text := strings.TrimSpace(current.String())
+		if text == "" {
+			return
+		}
+		chunks = append(chunks, Chunk{
+			Index:      chunkIndex,
+			Text:       text,
+			TokenCount: approxTokens(text),
+			Section:    chunkSection,
+		})
+		chunkIndex++
+
+		// Compute overlap: take the last OverlapTokens worth of text from the end.
+		words := strings.Fields(text)
+		// Each word ≈ 1 token for this heuristic (close enough).
+		overlap := 0
+		tail := []string{}
+		for i := len(words) - 1; i >= 0 && overlap < opts.OverlapTokens; i-- {
+			overlap += approxTokens(words[i])
+			tail = append([]string{words[i]}, tail...)
+		}
+		overlapTail = strings.Join(tail, " ")
+
+		current.Reset()
+		currentTokens = 0
+		// The new chunk inherits the current section context.
+		chunkSection = latestSection
+		if overlapTail != "" {
+			current.WriteString(overlapTail)
+			current.WriteByte('\n')
+			currentTokens = approxTokens(overlapTail)
+		}
+	}
+
+	for _, seg := range segments {
+		segTokens := approxTokens(seg)
+
+		// Flush before appending if this segment would overflow the target.
+		if currentTokens+segTokens > opts.TargetTokens && currentTokens > 0 {
+			flush()
+		}
+
+		// Detect a section header in this segment. We update latestSection
+		// before writing to current so that if this segment opens a new chunk
+		// (after flush above), chunkSection is already correct.
+		if m := sectionHeaderRe.FindString(seg); m != "" {
+			latestSection = strings.TrimSpace(m)
+			// If the current buffer is empty (just started or just flushed),
+			// update chunkSection immediately so this chunk carries the header.
+			if current.Len() == 0 || strings.TrimSpace(current.String()) == "" {
+				chunkSection = latestSection
+			}
+		}
+
+		if current.Len() > 0 {
+			current.WriteByte('\n')
+		}
+		current.WriteString(seg)
+		currentTokens += segTokens
+	}
+	flush()
+	return chunks
+}

--- a/backend/internal/service/research/ingest/chunk_test.go
+++ b/backend/internal/service/research/ingest/chunk_test.go
@@ -1,0 +1,96 @@
+package ingest
+
+import (
+	"strings"
+	"testing"
+)
+
+const fixtureText = `Item 1A. Risk Factors
+
+Apple faces many risks in its supply chain operations.
+Concentration of manufacturing in a single region poses challenges.
+Disruptions to logistics may impact revenue significantly.
+
+Item 7. Management Discussion and Analysis
+
+The company reported strong revenue growth in fiscal year 2024.
+Operating margins expanded due to product mix improvement.
+Services revenue reached a new all-time high.
+
+The following section discusses results in detail.
+Revenue increased year-over-year driven by iPhone sales.
+Mac revenue was flat compared to the prior year.
+iPad category declined modestly due to product cycle timing.`
+
+func TestChunkText_Count(t *testing.T) {
+	opts := ChunkOpts{TargetTokens: 50, OverlapTokens: 10}
+	chunks := ChunkText(fixtureText, opts)
+	if len(chunks) == 0 {
+		t.Fatal("expected at least one chunk")
+	}
+	// Each chunk should be under TargetTokens + a small buffer (overlap can push slightly over).
+	for _, c := range chunks {
+		// Allow up to 2× TargetTokens because a single sentence can exceed target.
+		if c.TokenCount > opts.TargetTokens*2 {
+			t.Errorf("chunk %d has %d tokens, expected <= %d", c.Index, c.TokenCount, opts.TargetTokens*2)
+		}
+	}
+}
+
+func TestChunkText_OverlapPresent(t *testing.T) {
+	opts := ChunkOpts{TargetTokens: 60, OverlapTokens: 15}
+	chunks := ChunkText(fixtureText, opts)
+	if len(chunks) < 2 {
+		t.Skip("not enough chunks to verify overlap")
+	}
+	// The start of chunk[1] should contain some words from the end of chunk[0].
+	lastWordsChunk0 := strings.Fields(chunks[0].Text)
+	if len(lastWordsChunk0) == 0 {
+		t.Fatal("chunk 0 is empty")
+	}
+	lastWord := lastWordsChunk0[len(lastWordsChunk0)-1]
+	if !strings.Contains(chunks[1].Text, lastWord) {
+		// Overlap is word-based so a word from the end of chunk[0] must appear in chunk[1].
+		// This is a soft check — overlap is approximate.
+		t.Errorf("overlap check: last word %q not found in chunk[1] (overlap broken)", lastWord)
+	}
+}
+
+func TestChunkText_SectionAttached(t *testing.T) {
+	opts := ChunkOpts{TargetTokens: 50, OverlapTokens: 5}
+	chunks := ChunkText(fixtureText, opts)
+
+	foundRisk := false
+	foundMDA := false
+	for _, c := range chunks {
+		if strings.Contains(c.Section, "1A") {
+			foundRisk = true
+		}
+		if strings.Contains(c.Section, "7") {
+			foundMDA = true
+		}
+	}
+	if !foundRisk {
+		t.Error("expected at least one chunk with section containing '1A'")
+	}
+	if !foundMDA {
+		t.Error("expected at least one chunk with section containing '7'")
+	}
+}
+
+func TestChunkText_IndexMonotonic(t *testing.T) {
+	opts := ChunkOpts{TargetTokens: 40, OverlapTokens: 10}
+	chunks := ChunkText(fixtureText, opts)
+	for i, c := range chunks {
+		if c.Index != i {
+			t.Errorf("chunk index mismatch: got %d, want %d", c.Index, i)
+		}
+	}
+}
+
+func TestChunkText_EmptyInput(t *testing.T) {
+	chunks := ChunkText("", ChunkOpts{TargetTokens: 500, OverlapTokens: 80})
+	if len(chunks) != 0 {
+		t.Errorf("expected 0 chunks for empty input, got %d", len(chunks))
+	}
+}

--- a/backend/internal/service/research/ingest/edgar.go
+++ b/backend/internal/service/research/ingest/edgar.go
@@ -1,0 +1,235 @@
+package ingest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"golang.org/x/net/html"
+	"golang.org/x/time/rate"
+)
+
+// maxFilingBytes caps an individual filing-body read so a pathological 10-K
+// (or a malicious server returning a giant body) cannot OOM the ingest job on
+// the e2-micro instance. A normal 10-K HTML is 2-15 MB; the cap leaves
+// generous headroom while keeping peak RSS bounded.
+const maxFilingBytes = 50 * 1024 * 1024
+
+// EdgarClient fetches filings from SEC EDGAR with the mandatory User-Agent
+// header and a 10 req/sec rate limiter as required by SEC fair-access policy.
+type EdgarClient struct {
+	httpClient *http.Client
+	userAgent  string
+	limiter    *rate.Limiter
+	// CIK map is populated lazily on first call to ResolveCIK; no refresh
+	// needed for the CLI use case.
+	tickerMap map[string]string
+}
+
+// Filing is a single SEC filing returned from the submissions endpoint.
+type Filing struct {
+	CIK             string
+	AccessionNumber string
+	FormType        string
+	PrimaryDocument string
+	FiledAt         string
+	URL             string
+}
+
+func NewEdgarClient(userAgent string) *EdgarClient {
+	return &EdgarClient{
+		httpClient: &http.Client{Timeout: 30 * time.Second},
+		userAgent:  userAgent,
+		// 10 req/sec with burst of 10 — SEC's documented limit.
+		limiter: rate.NewLimiter(10, 10),
+	}
+}
+
+// ResolveCIK maps a ticker symbol to a zero-padded 10-digit CIK string.
+// The result is cached in memory for the lifetime of the client.
+func (c *EdgarClient) ResolveCIK(ctx context.Context, symbol string) (string, error) {
+	if c.tickerMap == nil {
+		if err := c.loadTickerMap(ctx); err != nil {
+			return "", err
+		}
+	}
+	cik, ok := c.tickerMap[strings.ToUpper(symbol)]
+	if !ok {
+		return "", fmt.Errorf("edgar: CIK not found for symbol %q", symbol)
+	}
+	return cik, nil
+}
+
+func (c *EdgarClient) loadTickerMap(ctx context.Context) error {
+	body, err := c.get(ctx, "https://www.sec.gov/files/company_tickers.json")
+	if err != nil {
+		return fmt.Errorf("edgar: load ticker map: %w", err)
+	}
+	defer body.Close()
+
+	// Response is {"0":{"cik_str":789019,"ticker":"MSFT","title":"MICROSOFT CORP"}, ...}
+	var raw map[string]struct {
+		CIK    int    `json:"cik_str"`
+		Ticker string `json:"ticker"`
+	}
+	if err := json.NewDecoder(body).Decode(&raw); err != nil {
+		return fmt.Errorf("edgar: decode ticker map: %w", err)
+	}
+
+	c.tickerMap = make(map[string]string, len(raw))
+	for _, entry := range raw {
+		c.tickerMap[strings.ToUpper(entry.Ticker)] = fmt.Sprintf("%010d", entry.CIK)
+	}
+	return nil
+}
+
+// FetchRecentFilings returns up to n filings of the given form types for cik.
+func (c *EdgarClient) FetchRecentFilings(ctx context.Context, cik string, formTypes []string, n int) ([]Filing, error) {
+	url := fmt.Sprintf("https://data.sec.gov/submissions/CIK%s.json", cik)
+	body, err := c.get(ctx, url)
+	if err != nil {
+		return nil, fmt.Errorf("edgar: fetch submissions %s: %w", cik, err)
+	}
+	defer body.Close()
+
+	var sub struct {
+		Filings struct {
+			Recent struct {
+				AccessionNumber []string `json:"accessionNumber"`
+				Form            []string `json:"form"`
+				FilingDate      []string `json:"filingDate"`
+				PrimaryDocument []string `json:"primaryDocument"`
+			} `json:"recent"`
+		} `json:"filings"`
+	}
+	if err := json.NewDecoder(body).Decode(&sub); err != nil {
+		return nil, fmt.Errorf("edgar: decode submissions: %w", err)
+	}
+
+	allowedForms := make(map[string]bool, len(formTypes))
+	for _, ft := range formTypes {
+		allowedForms[ft] = true
+	}
+
+	r := sub.Filings.Recent
+	var results []Filing
+	for i := range r.AccessionNumber {
+		if !allowedForms[r.Form[i]] {
+			continue
+		}
+		accNoDashes := strings.ReplaceAll(r.AccessionNumber[i], "-", "")
+		docURL := fmt.Sprintf(
+			"https://www.sec.gov/Archives/edgar/data/%s/%s/%s",
+			strings.TrimLeft(cik, "0"), accNoDashes, r.PrimaryDocument[i],
+		)
+		results = append(results, Filing{
+			CIK:             cik,
+			AccessionNumber: r.AccessionNumber[i],
+			FormType:        r.Form[i],
+			PrimaryDocument: r.PrimaryDocument[i],
+			FiledAt:         r.FilingDate[i],
+			URL:             docURL,
+		})
+		if len(results) >= n {
+			break
+		}
+	}
+	return results, nil
+}
+
+// FetchFilingText downloads the filing's primary document and returns plain text.
+// HTML tags are stripped and XBRL noise is discarded.
+func (c *EdgarClient) FetchFilingText(ctx context.Context, f Filing) (string, error) {
+	body, err := c.get(ctx, f.URL)
+	if err != nil {
+		return "", fmt.Errorf("edgar: fetch filing %s: %w", f.URL, err)
+	}
+	defer body.Close()
+
+	raw, err := io.ReadAll(io.LimitReader(body, maxFilingBytes+1))
+	if err != nil {
+		return "", fmt.Errorf("edgar: read filing body: %w", err)
+	}
+	if len(raw) > maxFilingBytes {
+		return "", fmt.Errorf("edgar: filing body exceeds %d bytes: %s", maxFilingBytes, f.URL)
+	}
+
+	return stripHTML(string(raw)), nil
+}
+
+// get honours the SEC rate limit and sets the required User-Agent header.
+func (c *EdgarClient) get(ctx context.Context, url string) (io.ReadCloser, error) {
+	if err := c.limiter.Wait(ctx); err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", c.userAgent)
+	req.Header.Set("Accept", "application/json, text/html, */*")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		resp.Body.Close()
+		return nil, fmt.Errorf("edgar: HTTP %d for %s", resp.StatusCode, url)
+	}
+	return resp.Body, nil
+}
+
+// stripHTML walks the HTML parse tree, collecting visible text nodes.
+// <script> and <style> subtrees are skipped entirely.
+func stripHTML(rawHTML string) string {
+	doc, err := html.Parse(strings.NewReader(rawHTML))
+	if err != nil {
+		// If parse fails, return the raw text (still better than nothing).
+		return rawHTML
+	}
+
+	var sb strings.Builder
+	var walk func(*html.Node)
+	walk = func(n *html.Node) {
+		if n.Type == html.ElementNode {
+			tag := strings.ToLower(n.Data)
+			if tag == "script" || tag == "style" {
+				return
+			}
+		}
+		if n.Type == html.TextNode {
+			t := strings.TrimSpace(n.Data)
+			if t != "" {
+				sb.WriteString(t)
+				sb.WriteByte('\n')
+			}
+		}
+		for ch := n.FirstChild; ch != nil; ch = ch.NextSibling {
+			walk(ch)
+		}
+	}
+	walk(doc)
+
+	// Collapse runs of blank lines.
+	lines := strings.Split(sb.String(), "\n")
+	var out []string
+	blank := 0
+	for _, l := range lines {
+		if strings.TrimSpace(l) == "" {
+			blank++
+			if blank <= 1 {
+				out = append(out, "")
+			}
+		} else {
+			blank = 0
+			out = append(out, l)
+		}
+	}
+	return strings.Join(out, "\n")
+}

--- a/backend/internal/service/research/ingest/edgar_test.go
+++ b/backend/internal/service/research/ingest/edgar_test.go
@@ -1,0 +1,185 @@
+package ingest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// buildTestEdgarClient returns an EdgarClient pointed at the given httptest server.
+func buildTestEdgarClient(srv *httptest.Server, userAgent string) *EdgarClient {
+	c := NewEdgarClient(userAgent)
+	c.httpClient = srv.Client()
+	return c
+}
+
+func TestEdgarClient_UserAgentHeader(t *testing.T) {
+	var gotUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		// Serve a minimal company_tickers.json response.
+		json.NewEncoder(w).Encode(map[string]any{
+			"0": map[string]any{"cik_str": 320193, "ticker": "AAPL"},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewEdgarClient("PaperTrader test@example.com")
+	c.httpClient = srv.Client()
+	// Point all requests to the test server.
+	c.httpClient.Transport = rewriteHostTransport{target: srv.URL, inner: srv.Client().Transport}
+
+	// loadTickerMap issues one GET; we verify the UA is set.
+	if err := c.loadTickerMap(context.Background()); err != nil {
+		t.Fatalf("loadTickerMap: %v", err)
+	}
+	if gotUA != "PaperTrader test@example.com" {
+		t.Errorf("User-Agent = %q, want %q", gotUA, "PaperTrader test@example.com")
+	}
+}
+
+// rewriteHostTransport rewrites every request's host to a fixed target URL.
+type rewriteHostTransport struct {
+	target string
+	inner  http.RoundTripper
+}
+
+func (t rewriteHostTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	cloned := req.Clone(req.Context())
+	cloned.URL.Scheme = "http"
+	cloned.URL.Host = t.target[len("http://"):]
+	return t.inner.RoundTrip(cloned)
+}
+
+func TestEdgarClient_CIKPadding(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"0": map[string]any{"cik_str": 320193, "ticker": "AAPL"},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewEdgarClient("PaperTrader test@example.com")
+	c.httpClient = srv.Client()
+	c.httpClient.Transport = rewriteHostTransport{target: srv.URL, inner: srv.Client().Transport}
+
+	if err := c.loadTickerMap(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	cik, ok := c.tickerMap["AAPL"]
+	if !ok {
+		t.Fatal("AAPL not in ticker map")
+	}
+	if len(cik) != 10 {
+		t.Errorf("CIK length = %d, want 10 digits; got %q", len(cik), cik)
+	}
+	if cik != "0000320193" {
+		t.Errorf("CIK = %q, want 0000320193", cik)
+	}
+}
+
+func TestEdgarClient_PrimaryDocumentURL(t *testing.T) {
+	submissionsBody, _ := json.Marshal(map[string]any{
+		"filings": map[string]any{
+			"recent": map[string]any{
+				"accessionNumber": []string{"0000320193-24-000123"},
+				"form":            []string{"10-K"},
+				"filingDate":      []string{"2024-11-01"},
+				"primaryDocument": []string{"aapl-20240928.htm"},
+			},
+		},
+	})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(submissionsBody)
+	}))
+	defer srv.Close()
+
+	c := NewEdgarClient("PaperTrader test@example.com")
+	c.httpClient = srv.Client()
+	c.httpClient.Transport = rewriteHostTransport{target: srv.URL, inner: srv.Client().Transport}
+
+	// Pre-populate CIK map so we skip the ticker endpoint.
+	c.tickerMap = map[string]string{"AAPL": "0000320193"}
+
+	filings, err := c.FetchRecentFilings(context.Background(), "0000320193", []string{"10-K"}, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filings) != 1 {
+		t.Fatalf("expected 1 filing, got %d", len(filings))
+	}
+	want := "https://www.sec.gov/Archives/edgar/data/320193/000032019324000123/aapl-20240928.htm"
+	if filings[0].URL != want {
+		t.Errorf("URL = %q\nwant %q", filings[0].URL, want)
+	}
+}
+
+func TestEdgarClient_RateLimiter(t *testing.T) {
+	var calls int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&calls, 1)
+		json.NewEncoder(w).Encode(map[string]any{
+			"0": map[string]any{"cik_str": 320193, "ticker": "AAPL"},
+		})
+	}))
+	defer srv.Close()
+
+	c := NewEdgarClient("PaperTrader test@example.com")
+	c.httpClient = srv.Client()
+	c.httpClient.Transport = rewriteHostTransport{target: srv.URL, inner: srv.Client().Transport}
+
+	// 12 requests at 10/sec should take at least 1 second (the 11th request
+	// burns the burst and waits for a new token).
+	n := 12
+	start := time.Now()
+	ctx := context.Background()
+	for i := 0; i < n; i++ {
+		// Reset ticker map each iteration so loadTickerMap fires again.
+		c.tickerMap = nil
+		if err := c.loadTickerMap(ctx); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	elapsed := time.Since(start)
+
+	// With 10 req/sec and a burst of 10, 12 calls take at least 200ms.
+	// We use a generous lower bound of 100ms to avoid flakiness on slow CI.
+	minExpected := 100 * time.Millisecond
+	if elapsed < minExpected {
+		t.Errorf("12 calls completed in %v, expected >= %v (rate limiter may not be active)", elapsed, minExpected)
+	}
+	if atomic.LoadInt64(&calls) != int64(n) {
+		t.Errorf("expected %d HTTP calls, got %d", n, calls)
+	}
+}
+
+func TestEdgarClient_URLFormat(t *testing.T) {
+	cases := []struct {
+		accession     string
+		primaryDoc    string
+		cik           string
+		wantURLSuffix string
+	}{
+		{
+			accession:     "0000320193-24-000123",
+			primaryDoc:    "aapl-20240928.htm",
+			cik:           "0000320193",
+			wantURLSuffix: "/Archives/edgar/data/320193/000032019324000123/aapl-20240928.htm",
+		},
+	}
+	for _, tc := range cases {
+		accNoDashes := strings.ReplaceAll(tc.accession, "-", "")
+		got := fmt.Sprintf("https://www.sec.gov/Archives/edgar/data/%s/%s/%s",
+			strings.TrimLeft(tc.cik, "0"), accNoDashes, tc.primaryDoc)
+		if !strings.HasSuffix(got, tc.wantURLSuffix) {
+			t.Errorf("URL = %q, want suffix %q", got, tc.wantURLSuffix)
+		}
+	}
+}

--- a/backend/internal/service/research/ingest/pipeline.go
+++ b/backend/internal/service/research/ingest/pipeline.go
@@ -1,0 +1,303 @@
+package ingest
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"papertrader/internal/data"
+	"papertrader/internal/service/research"
+)
+
+// filingFetcher is the EdgarClient subset used by Pipeline.
+type filingFetcher interface {
+	ResolveCIK(ctx context.Context, symbol string) (string, error)
+	FetchRecentFilings(ctx context.Context, cik string, formTypes []string, n int) ([]Filing, error)
+	FetchFilingText(ctx context.Context, f Filing) (string, error)
+}
+
+// documentStore is the DocumentsStore subset used by Pipeline.
+type documentStore interface {
+	GetByID(ctx context.Context, id string) (*data.Document, error)
+	Upsert(ctx context.Context, doc data.Document) error
+}
+
+// chunkStore is the ChunksStore subset used by Pipeline.
+type chunkStore interface {
+	BulkInsert(ctx context.Context, chunks []data.Chunk) error
+	GetByDocumentID(ctx context.Context, docID string) ([]data.Chunk, error)
+}
+
+// embeddingStore is the EmbeddingsStore subset used by Pipeline.
+type embeddingStore interface {
+	Upsert(ctx context.Context, chunkID string, vec []float32, model string) error
+	Exists(ctx context.Context, chunkID string) (bool, error)
+}
+
+// Pipeline orchestrates the full ingest flow: fetch → chunk → embed → store.
+// Processing is deliberately serial (one filing at a time) to keep the RAM
+// footprint predictable on the constrained e2-micro instance. A single 10-K
+// can spike to ~80 MB while chunks are held in memory during embedding.
+type Pipeline struct {
+	edgar      filingFetcher
+	embedder   research.Embedder
+	docs       documentStore
+	chunks     chunkStore
+	embeddings embeddingStore
+}
+
+// IngestOpts controls ingest behaviour.
+type IngestOpts struct {
+	FormTypes  []string
+	MaxFilings int
+	Force      bool
+}
+
+// IngestResult summarises what changed.
+type IngestResult struct {
+	DocumentsAdded  int
+	ChunksAdded     int
+	EmbeddingsAdded int
+	Skipped         int
+}
+
+func NewPipeline(
+	edgar *EdgarClient,
+	embedder research.Embedder,
+	docs *data.DocumentsStore,
+	chunks *data.ChunksStore,
+	embeddings *data.EmbeddingsStore,
+) *Pipeline {
+	return &Pipeline{
+		edgar:      edgar,
+		embedder:   embedder,
+		docs:       docs,
+		chunks:     chunks,
+		embeddings: embeddings,
+	}
+}
+
+// IngestSymbol ingests recent SEC filings for one ticker symbol.
+func (p *Pipeline) IngestSymbol(ctx context.Context, symbol string, opts IngestOpts) (*IngestResult, error) {
+	formTypes := opts.FormTypes
+	if len(formTypes) == 0 {
+		formTypes = []string{"10-K", "10-Q", "8-K"}
+	}
+	maxFilings := opts.MaxFilings
+	if maxFilings <= 0 {
+		maxFilings = 5
+	}
+
+	cik, err := p.edgar.ResolveCIK(ctx, symbol)
+	if err != nil {
+		return nil, fmt.Errorf("ingest %s: %w", symbol, err)
+	}
+
+	filings, err := p.edgar.FetchRecentFilings(ctx, cik, formTypes, maxFilings)
+	if err != nil {
+		return nil, fmt.Errorf("ingest %s: %w", symbol, err)
+	}
+
+	result := &IngestResult{}
+	for _, f := range filings {
+		if err := p.ingestFiling(ctx, symbol, f, opts, result); err != nil {
+			slog.Warn("ingest: filing failed, continuing", "url", f.URL, "err", err)
+		}
+	}
+	return result, nil
+}
+
+func (p *Pipeline) ingestFiling(ctx context.Context, symbol string, f Filing, opts IngestOpts, result *IngestResult) error {
+	// Defense in depth: source_url is rendered as a link in the frontend, so
+	// reject any scheme that could execute in the browser. The DB also has a
+	// CHECK constraint, but failing here gives a clearer error than a constraint
+	// violation deep in the stack.
+	if !isSafeHTTPURL(f.URL) {
+		return fmt.Errorf("ingest: refusing non-http(s) source_url: %s", f.URL)
+	}
+
+	docID := docIDFromURL(f.URL)
+
+	if !opts.Force {
+		existing, err := p.docs.GetByID(ctx, docID)
+		if err != nil {
+			return fmt.Errorf("check existing doc: %w", err)
+		}
+
+		if existing != nil {
+			// Document exists — check whether all chunks have embeddings. If any
+			// are missing this is a partial failure from a prior run; backfill only
+			// the unembedded chunks rather than skipping the filing entirely.
+			chunks, err := p.chunks.GetByDocumentID(ctx, docID)
+			if err != nil {
+				return fmt.Errorf("get chunks for backfill check: %w", err)
+			}
+
+			var toEmbed []data.Chunk
+			for _, c := range chunks {
+				exists, err := p.embeddings.Exists(ctx, c.ID)
+				if err != nil {
+					return fmt.Errorf("check embedding exists for %s: %w", c.ID, err)
+				}
+				if !exists {
+					toEmbed = append(toEmbed, c)
+				}
+			}
+
+			if len(toEmbed) == 0 {
+				result.Skipped++
+				slog.Info("ingest: skipping existing document (all chunks embedded)", "url", f.URL)
+				return nil
+			}
+
+			slog.Info("ingest: backfilling missing embeddings", "url", f.URL, "count", len(toEmbed))
+			if err := p.embedAndStore(ctx, toEmbed, false); err != nil {
+				slog.Warn("ingest: backfill failed, continuing", "url", f.URL, "err", err)
+				return nil
+			}
+			result.EmbeddingsAdded += len(toEmbed)
+			return nil
+		}
+	}
+
+	text, err := p.edgar.FetchFilingText(ctx, f)
+	if err != nil {
+		return fmt.Errorf("fetch text: %w", err)
+	}
+
+	rawChunks := ChunkText(text, ChunkOpts{TargetTokens: 500, OverlapTokens: 80})
+	if len(rawChunks) == 0 {
+		slog.Warn("ingest: no chunks produced", "url", f.URL)
+		return nil
+	}
+
+	var filedAt *time.Time
+	if f.FiledAt != "" {
+		t, err := time.Parse("2006-01-02", f.FiledAt)
+		if err == nil {
+			filedAt = &t
+		}
+	}
+
+	doc := data.Document{
+		ID:         docID,
+		SourceType: "sec_filing",
+		SourceURL:  f.URL,
+		Symbol:     symbol,
+		Title:      fmt.Sprintf("%s %s", f.FormType, f.FiledAt),
+		FiledAt:    filedAt,
+		Metadata:   []byte(fmt.Sprintf(`{"form_type":%q,"cik":%q,"accession":%q}`, f.FormType, f.CIK, f.AccessionNumber)),
+	}
+	if err := p.docs.Upsert(ctx, doc); err != nil {
+		return fmt.Errorf("upsert doc: %w", err)
+	}
+	result.DocumentsAdded++
+
+	dataChunks := make([]data.Chunk, len(rawChunks))
+	for i, c := range rawChunks {
+		dataChunks[i] = data.Chunk{
+			ID:         chunkID(docID, c.Index),
+			DocumentID: docID,
+			ChunkIndex: c.Index,
+			Text:       c.Text,
+			TokenCount: c.TokenCount,
+			Section:    c.Section,
+		}
+	}
+	if err := p.chunks.BulkInsert(ctx, dataChunks); err != nil {
+		return fmt.Errorf("bulk insert chunks: %w", err)
+	}
+	result.ChunksAdded += len(dataChunks)
+
+	if err := p.embedAndStore(ctx, dataChunks, opts.Force); err != nil {
+		return err
+	}
+	result.EmbeddingsAdded += len(dataChunks)
+
+	return nil
+}
+
+// embedAndStore embeds chunks in batches of 32 and upserts each embedding.
+// When force is false it skips chunks that already have an embedding, protecting
+// against double-work on partial-batch failures even on the new-document path.
+// When force is true the existence check is skipped — the caller explicitly
+// wants every chunk re-embedded.
+func (p *Pipeline) embedAndStore(ctx context.Context, chunks []data.Chunk, force bool) error {
+	const batchSize = 32
+
+	for start := 0; start < len(chunks); start += batchSize {
+		end := start + batchSize
+		if end > len(chunks) {
+			end = len(chunks)
+		}
+		batch := chunks[start:end]
+
+		// Filter to chunks that still need embedding when not forcing.
+		toEmbed := batch
+		if !force {
+			filtered := batch[:0:len(batch)]
+			for _, c := range batch {
+				exists, err := p.embeddings.Exists(ctx, c.ID)
+				if err != nil {
+					return fmt.Errorf("check embedding exists for %s: %w", c.ID, err)
+				}
+				if !exists {
+					filtered = append(filtered, c)
+				}
+			}
+			toEmbed = filtered
+		}
+
+		if len(toEmbed) == 0 {
+			continue
+		}
+
+		texts := make([]string, len(toEmbed))
+		for i, c := range toEmbed {
+			texts[i] = c.Text
+		}
+
+		vecs, _, err := p.embedder.EmbedBatch(ctx, texts)
+		if err != nil {
+			return fmt.Errorf("embed batch [%d:%d]: %w", start, end, err)
+		}
+
+		for i, c := range toEmbed {
+			if err := p.embeddings.Upsert(ctx, c.ID, vecs[i], p.embedder.Model()); err != nil {
+				return fmt.Errorf("upsert embedding %s: %w", c.ID, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// isSafeHTTPURL returns true only for http:// and https:// URLs. Anything else
+// (javascript:, data:, file:, schemeless) is rejected before the URL enters the
+// documents table and, transitively, the frontend.
+func isSafeHTTPURL(u string) bool {
+	return strings.HasPrefix(u, "http://") || strings.HasPrefix(u, "https://")
+}
+
+func docIDFromURL(url string) string {
+	sum := sha256.Sum256([]byte(url))
+	return fmt.Sprintf("%x", sum[:32])
+}
+
+func chunkID(docID string, index int) string {
+	sum := sha256.Sum256([]byte(fmt.Sprintf("%s:%d", docID, index)))
+	return fmt.Sprintf("%x", sum[:32])
+}
+
+// ChunkIDFromParts is exported for use in tests.
+func ChunkIDFromParts(docID string, index int) string {
+	return chunkID(docID, index)
+}
+
+// DocIDFromURL is exported for use in tests and the CLI.
+func DocIDFromURL(url string) string {
+	return docIDFromURL(url)
+}

--- a/backend/internal/service/research/ingest/pipeline_test.go
+++ b/backend/internal/service/research/ingest/pipeline_test.go
@@ -1,0 +1,275 @@
+package ingest
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"papertrader/internal/data"
+	"papertrader/internal/service/research"
+)
+
+// --- stubs ---
+
+type stubFetcher struct {
+	filings     []Filing
+	fetchCalled map[string]int // url → call count
+	textByURL   map[string]string
+}
+
+func newStubFetcher(filings []Filing, textByURL map[string]string) *stubFetcher {
+	return &stubFetcher{filings: filings, fetchCalled: map[string]int{}, textByURL: textByURL}
+}
+
+func (s *stubFetcher) ResolveCIK(_ context.Context, _ string) (string, error) {
+	return "0000000001", nil
+}
+
+func (s *stubFetcher) FetchRecentFilings(_ context.Context, _ string, _ []string, _ int) ([]Filing, error) {
+	return s.filings, nil
+}
+
+func (s *stubFetcher) FetchFilingText(_ context.Context, f Filing) (string, error) {
+	s.fetchCalled[f.URL]++
+	if t, ok := s.textByURL[f.URL]; ok {
+		return t, nil
+	}
+	return strings.Repeat("word ", 200), nil
+}
+
+type stubDocStore struct {
+	existing map[string]*data.Document // id → doc (nil means not found)
+	upserted []data.Document
+}
+
+func newStubDocStore(existing map[string]*data.Document) *stubDocStore {
+	return &stubDocStore{existing: existing}
+}
+
+func (s *stubDocStore) GetByID(_ context.Context, id string) (*data.Document, error) {
+	if doc, ok := s.existing[id]; ok {
+		return doc, nil
+	}
+	return nil, nil
+}
+
+func (s *stubDocStore) Upsert(_ context.Context, doc data.Document) error {
+	s.upserted = append(s.upserted, doc)
+	return nil
+}
+
+type stubChunkStore struct {
+	inserted    int
+	chunksByDoc map[string][]data.Chunk // docID → chunks (for GetByDocumentID)
+}
+
+func (s *stubChunkStore) BulkInsert(_ context.Context, chunks []data.Chunk) error {
+	s.inserted += len(chunks)
+	return nil
+}
+
+func (s *stubChunkStore) GetByDocumentID(_ context.Context, docID string) ([]data.Chunk, error) {
+	return s.chunksByDoc[docID], nil
+}
+
+type stubEmbeddingStore struct {
+	upserted    int
+	embedCalled []string       // chunk IDs passed to Upsert, in order
+	existing    map[string]bool // chunk IDs that already have embeddings
+}
+
+func (s *stubEmbeddingStore) Upsert(_ context.Context, chunkID string, _ []float32, _ string) error {
+	s.upserted++
+	s.embedCalled = append(s.embedCalled, chunkID)
+	return nil
+}
+
+func (s *stubEmbeddingStore) Exists(_ context.Context, chunkID string) (bool, error) {
+	return s.existing[chunkID], nil
+}
+
+type stubBatchEmbedder struct {
+	batchCallCount int
+	inputsSeen     []string
+}
+
+func (s *stubBatchEmbedder) EmbedQuery(_ context.Context, _ string) ([]float32, int, error) {
+	return []float32{0.1, 0.2}, 10, nil
+}
+
+func (s *stubBatchEmbedder) EmbedBatch(_ context.Context, texts []string) ([][]float32, int, error) {
+	s.batchCallCount++
+	s.inputsSeen = append(s.inputsSeen, texts...)
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		out[i] = []float32{0.1, 0.2}
+	}
+	return out, len(texts) * 10, nil
+}
+
+func (s *stubBatchEmbedder) Model() string { return "stub" }
+
+var _ research.Embedder = (*stubBatchEmbedder)(nil)
+
+// buildPipeline wires up a Pipeline from the given stubs.
+func buildPipeline(
+	fetcher filingFetcher,
+	docs documentStore,
+	chunks chunkStore,
+	embeddings embeddingStore,
+	embedder research.Embedder,
+) *Pipeline {
+	return &Pipeline{
+		edgar:      fetcher,
+		embedder:   embedder,
+		docs:       docs,
+		chunks:     chunks,
+		embeddings: embeddings,
+	}
+}
+
+// --- tests ---
+
+// TestPipeline_Idempotency checks that a filing whose doc ID already exists
+// and all chunks are embedded is skipped: FetchFilingText is NOT called and
+// Skipped is incremented.
+func TestPipeline_Idempotency(t *testing.T) {
+	filingURL := "https://www.sec.gov/Archives/edgar/data/1/000000000124000001/doc.htm"
+	existingURL := "https://www.sec.gov/Archives/edgar/data/1/000000000124000002/old.htm"
+
+	newFiling := Filing{URL: filingURL, FormType: "10-K", FiledAt: "2024-01-01", CIK: "0000000001", AccessionNumber: "0000000001-24-000001"}
+	oldFiling := Filing{URL: existingURL, FormType: "10-K", FiledAt: "2023-01-01", CIK: "0000000001", AccessionNumber: "0000000001-23-000002"}
+
+	existingDocID := DocIDFromURL(existingURL)
+	existingDoc := &data.Document{ID: existingDocID, SourceURL: existingURL}
+
+	// The old filing already has one chunk with an embedding.
+	existingChunkID := ChunkIDFromParts(existingDocID, 0)
+	chunkSt := &stubChunkStore{
+		chunksByDoc: map[string][]data.Chunk{
+			existingDocID: {{ID: existingChunkID, DocumentID: existingDocID, ChunkIndex: 0, Text: "old text", TokenCount: 2}},
+		},
+	}
+	embSt := &stubEmbeddingStore{existing: map[string]bool{existingChunkID: true}}
+
+	fetcher := newStubFetcher([]Filing{oldFiling, newFiling}, nil)
+	docs := newStubDocStore(map[string]*data.Document{existingDocID: existingDoc})
+
+	p := buildPipeline(fetcher, docs, chunkSt, embSt, &stubBatchEmbedder{})
+	result, err := p.IngestSymbol(context.Background(), "TEST", IngestOpts{FormTypes: []string{"10-K"}, MaxFilings: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Skipped != 1 {
+		t.Errorf("Skipped = %d, want 1", result.Skipped)
+	}
+	if fetcher.fetchCalled[existingURL] != 0 {
+		t.Errorf("FetchFilingText called for existing filing %q; should have been skipped", existingURL)
+	}
+	if result.DocumentsAdded != 1 {
+		t.Errorf("DocumentsAdded = %d, want 1 (the new filing)", result.DocumentsAdded)
+	}
+}
+
+// TestPipeline_HappyPath verifies that a new filing is fully processed:
+// text fetched, chunks inserted, embeddings upserted, counts match.
+func TestPipeline_HappyPath(t *testing.T) {
+	// ~200 words × 5 chars avg = ~250 tokens → ChunkText(500) should produce 1 chunk.
+	filingText := strings.Repeat("word ", 200)
+	filingURL := "https://www.sec.gov/Archives/edgar/data/1/000000000124000001/doc.htm"
+	filing := Filing{URL: filingURL, FormType: "10-K", FiledAt: "2024-01-01", CIK: "0000000001", AccessionNumber: "0000000001-24-000001"}
+
+	fetcher := newStubFetcher([]Filing{filing}, map[string]string{filingURL: filingText})
+	docs := newStubDocStore(nil)
+	chunkSt := &stubChunkStore{}
+	embSt := &stubEmbeddingStore{existing: map[string]bool{}}
+
+	p := buildPipeline(fetcher, docs, chunkSt, embSt, &stubBatchEmbedder{})
+	result, err := p.IngestSymbol(context.Background(), "TEST", IngestOpts{FormTypes: []string{"10-K"}, MaxFilings: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.DocumentsAdded != 1 {
+		t.Errorf("DocumentsAdded = %d, want 1", result.DocumentsAdded)
+	}
+	if result.ChunksAdded == 0 {
+		t.Error("ChunksAdded = 0, want > 0")
+	}
+	if result.EmbeddingsAdded != result.ChunksAdded {
+		t.Errorf("EmbeddingsAdded = %d, want %d (one per chunk)", result.EmbeddingsAdded, result.ChunksAdded)
+	}
+	if chunkSt.inserted != result.ChunksAdded {
+		t.Errorf("stubChunkStore.inserted = %d, want %d", chunkSt.inserted, result.ChunksAdded)
+	}
+	if embSt.upserted != result.EmbeddingsAdded {
+		t.Errorf("stubEmbeddingStore.upserted = %d, want %d", embSt.upserted, result.EmbeddingsAdded)
+	}
+	if result.Skipped != 0 {
+		t.Errorf("Skipped = %d, want 0", result.Skipped)
+	}
+}
+
+// TestPipeline_BackfillMissingEmbeddings simulates a partial-embedding failure:
+// the document exists, 5 chunks exist in the DB, 2 already have embeddings, 3
+// don't. After IngestSymbol (force=false) the embedder must be called for exactly
+// 3 chunks and EmbeddingsAdded must equal 3. FetchFilingText must NOT be called.
+func TestPipeline_BackfillMissingEmbeddings(t *testing.T) {
+	filingURL := "https://www.sec.gov/Archives/edgar/data/1/000000000124000001/partial.htm"
+	filing := Filing{URL: filingURL, FormType: "10-K", FiledAt: "2024-01-01", CIK: "0000000001", AccessionNumber: "0000000001-24-000001"}
+
+	docID := DocIDFromURL(filingURL)
+	existingDoc := &data.Document{ID: docID, SourceURL: filingURL}
+
+	// Build 5 chunks; indices 0 and 1 already have embeddings.
+	var dbChunks []data.Chunk
+	embeddedIDs := map[string]bool{}
+	for i := 0; i < 5; i++ {
+		cid := ChunkIDFromParts(docID, i)
+		dbChunks = append(dbChunks, data.Chunk{
+			ID:         cid,
+			DocumentID: docID,
+			ChunkIndex: i,
+			Text:       strings.Repeat("word ", 20),
+			TokenCount: 20,
+		})
+		if i < 2 {
+			embeddedIDs[cid] = true
+		}
+	}
+
+	fetcher := newStubFetcher([]Filing{filing}, nil)
+	docs := newStubDocStore(map[string]*data.Document{docID: existingDoc})
+	chunkSt := &stubChunkStore{
+		chunksByDoc: map[string][]data.Chunk{docID: dbChunks},
+	}
+	embSt := &stubEmbeddingStore{existing: embeddedIDs}
+	embedder := &stubBatchEmbedder{}
+
+	p := buildPipeline(fetcher, docs, chunkSt, embSt, embedder)
+	result, err := p.IngestSymbol(context.Background(), "TEST", IngestOpts{
+		FormTypes:  []string{"10-K"},
+		MaxFilings: 5,
+		Force:      false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if fetcher.fetchCalled[filingURL] != 0 {
+		t.Errorf("FetchFilingText called %d time(s); want 0 (doc already exists)", fetcher.fetchCalled[filingURL])
+	}
+	if result.EmbeddingsAdded != 3 {
+		t.Errorf("EmbeddingsAdded = %d, want 3", result.EmbeddingsAdded)
+	}
+	if embSt.upserted != 3 {
+		t.Errorf("embeddings upserted = %d, want 3", embSt.upserted)
+	}
+	if len(embedder.inputsSeen) != 3 {
+		t.Errorf("embedder received %d texts, want 3", len(embedder.inputsSeen))
+	}
+	if result.Skipped != 0 {
+		t.Errorf("Skipped = %d, want 0 (partial fill should not count as skipped)", result.Skipped)
+	}
+}

--- a/backend/internal/service/research/llm.go
+++ b/backend/internal/service/research/llm.go
@@ -1,0 +1,157 @@
+package research
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// LLMOpts configures a single LLM call.
+type LLMOpts struct {
+	Temperature float64
+	MaxTokens   int
+	JSONMode    bool
+}
+
+// LLMResult holds the raw output from an LLM call.
+type LLMResult struct {
+	Content          string
+	PromptTokens     int
+	CompletionTokens int
+}
+
+// LLMClient is the interface all generation backends must satisfy.
+type LLMClient interface {
+	Generate(ctx context.Context, system, user string, opts LLMOpts) (LLMResult, error)
+	Model() string
+	// PriceMicrosPer1KTokens returns the list-price in USD micros per 1 000 tokens
+	// for input and output respectively. Free-tier callers still use these values
+	// to record a "would-be cost" metric.
+	PriceMicrosPer1KTokens() (in, out int)
+}
+
+// GroqClient implements LLMClient against the Groq OpenAI-compatible endpoint.
+type GroqClient struct {
+	httpClient *http.Client
+	apiKey     string
+	model      string
+}
+
+func NewGroqClient(apiKey string) *GroqClient {
+	return &GroqClient{
+		httpClient: &http.Client{Timeout: 60 * time.Second},
+		apiKey:     apiKey,
+		model:      "llama-3.3-70b-versatile",
+	}
+}
+
+// NewGroqClientWithModel constructs a GroqClient targeting the given model.
+// Useful when a caller needs a different model than the default generation model
+// (e.g., a lightweight judge model for eval).
+func NewGroqClientWithModel(apiKey, model string) *GroqClient {
+	return &GroqClient{
+		httpClient: &http.Client{Timeout: 60 * time.Second},
+		apiKey:     apiKey,
+		model:      model,
+	}
+}
+
+func (g *GroqClient) Model() string { return g.model }
+
+// groqModelPrices maps known Groq model names to their USD-micros-per-1K-token rates.
+// Source: Groq published list prices (May 2026).
+// Unknown models fall back to llama-3.3-70b-versatile rates rather than zero to
+// avoid silently reporting $0 cost for new models added before this table is updated.
+var groqModelPrices = map[string]struct{ in, out int }{
+	"llama-3.3-70b-versatile": {59, 79},
+	"llama-3.1-8b-instant":    {5, 8},
+}
+
+// PriceMicrosPer1KTokens returns Groq's published rates in USD micros per 1 000
+// tokens for the client's configured model. Falls back to llama-3.3-70b-versatile
+// rates for unrecognised models so cost is over-estimated rather than silently zero.
+func (g *GroqClient) PriceMicrosPer1KTokens() (in, out int) {
+	if p, ok := groqModelPrices[g.model]; ok {
+		return p.in, p.out
+	}
+	return 59, 79
+}
+
+func (g *GroqClient) Generate(ctx context.Context, system, user string, opts LLMOpts) (LLMResult, error) {
+	temp := opts.Temperature
+	maxTok := opts.MaxTokens
+	if maxTok == 0 {
+		maxTok = 800
+	}
+
+	type message struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	type responseFormat struct {
+		Type string `json:"type"`
+	}
+
+	body := map[string]any{
+		"model":       g.model,
+		"messages":    []message{{Role: "system", Content: system}, {Role: "user", Content: user}},
+		"temperature": temp,
+		"max_tokens":  maxTok,
+	}
+	if opts.JSONMode {
+		body["response_format"] = responseFormat{Type: "json_object"}
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return LLMResult{}, fmt.Errorf("groq generate: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		"https://api.groq.com/openai/v1/chat/completions",
+		bytes.NewReader(payload))
+	if err != nil {
+		return LLMResult{}, fmt.Errorf("groq generate: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+g.apiKey)
+
+	resp, err := g.httpClient.Do(req)
+	if err != nil {
+		return LLMResult{}, fmt.Errorf("groq generate: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		limited, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return LLMResult{}, fmt.Errorf("groq generate: status %d: %s", resp.StatusCode, limited)
+	}
+
+	var result struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+		Usage struct {
+			PromptTokens     int `json:"prompt_tokens"`
+			CompletionTokens int `json:"completion_tokens"`
+		} `json:"usage"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return LLMResult{}, fmt.Errorf("groq generate: decode response: %w", err)
+	}
+	if len(result.Choices) == 0 {
+		return LLMResult{}, fmt.Errorf("groq generate: empty choices in response")
+	}
+
+	return LLMResult{
+		Content:          result.Choices[0].Message.Content,
+		PromptTokens:     result.Usage.PromptTokens,
+		CompletionTokens: result.Usage.CompletionTokens,
+	}, nil
+}

--- a/backend/internal/service/research/llm_cache.go
+++ b/backend/internal/service/research/llm_cache.go
@@ -1,0 +1,75 @@
+package research
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/gob"
+	"fmt"
+	"log/slog"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// CachedLLMClient wraps any LLMClient with a Redis-backed persistent cache.
+// TTL is 0 (no expiry) — appropriate for eval runs where replay stability matters
+// more than cache freshness. Flush manually with redis-cli DEL or FLUSHDB.
+type CachedLLMClient struct {
+	inner       LLMClient
+	redisClient *redis.Client
+	keyPrefix   string
+}
+
+func NewCachedLLMClient(inner LLMClient, redisClient *redis.Client, keyPrefix string) *CachedLLMClient {
+	return &CachedLLMClient{
+		inner:       inner,
+		redisClient: redisClient,
+		keyPrefix:   keyPrefix,
+	}
+}
+
+func (c *CachedLLMClient) Model() string { return c.inner.Model() }
+
+func (c *CachedLLMClient) PriceMicrosPer1KTokens() (in, out int) {
+	return c.inner.PriceMicrosPer1KTokens()
+}
+
+func (c *CachedLLMClient) Generate(ctx context.Context, system, user string, opts LLMOpts) (LLMResult, error) {
+	if c.redisClient == nil {
+		slog.Debug("llm cache bypassed: no redis client")
+		return c.inner.Generate(ctx, system, user, opts)
+	}
+
+	key := c.cacheKey(system, user, opts)
+
+	if cached, err := c.redisClient.Get(ctx, key).Bytes(); err == nil {
+		var result LLMResult
+		if gobErr := gob.NewDecoder(bytes.NewReader(cached)).Decode(&result); gobErr == nil {
+			return result, nil
+		}
+	}
+
+	result, err := c.inner.Generate(ctx, system, user, opts)
+	if err != nil {
+		return LLMResult{}, err
+	}
+
+	var buf bytes.Buffer
+	if gobErr := gob.NewEncoder(&buf).Encode(result); gobErr == nil {
+		// 0 TTL means no expiry — best-effort, ignore cache write errors.
+		_ = c.redisClient.Set(ctx, key, buf.Bytes(), 0).Err()
+	}
+
+	return result, nil
+}
+
+func (c *CachedLLMClient) cacheKey(system, user string, opts LLMOpts) string {
+	// Include all fields that can change the output so distinct calls never collide.
+	// MaxTokens sits between Temperature and JSONMode; prefix collisions are harmless
+	// here because eval:gen and eval:judge use different keyPrefix values, but
+	// omitting MaxTokens would silently collide if two calls differed only there.
+	raw := fmt.Sprintf("%s\x00%s\x00%s\x00%v\x00%d\x00%v",
+		c.inner.Model(), system, user, opts.Temperature, opts.MaxTokens, opts.JSONMode)
+	sum := sha256.Sum256([]byte(raw))
+	return c.keyPrefix + fmt.Sprintf("%x", sum)
+}

--- a/backend/internal/service/research/llm_cache_test.go
+++ b/backend/internal/service/research/llm_cache_test.go
@@ -1,0 +1,143 @@
+package research
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+	"testing"
+)
+
+// stubCountLLM records how many times Generate is called.
+// modelName defaults to "stub-model" when empty.
+type stubCountLLM struct {
+	result    LLMResult
+	err       error
+	calls     int
+	modelName string
+}
+
+func (s *stubCountLLM) Generate(_ context.Context, _, _ string, _ LLMOpts) (LLMResult, error) {
+	s.calls++
+	return s.result, s.err
+}
+func (s *stubCountLLM) Model() string {
+	if s.modelName != "" {
+		return s.modelName
+	}
+	return "stub-model"
+}
+func (s *stubCountLLM) PriceMicrosPer1KTokens() (int, int) { return 10, 20 }
+
+func TestCachedLLMClient_NilRedis_AlwaysDelegates(t *testing.T) {
+	inner := &stubCountLLM{result: LLMResult{Content: "hello", PromptTokens: 5, CompletionTokens: 3}}
+	c := NewCachedLLMClient(inner, nil, "test:")
+
+	for i := 0; i < 3; i++ {
+		res, err := c.Generate(context.Background(), "sys", "usr", LLMOpts{})
+		if err != nil {
+			t.Fatalf("call %d: unexpected error: %v", i+1, err)
+		}
+		if res.Content != "hello" {
+			t.Errorf("call %d: content = %q, want %q", i+1, res.Content, "hello")
+		}
+	}
+	if inner.calls != 3 {
+		t.Errorf("inner.calls = %d, want 3", inner.calls)
+	}
+}
+
+func TestCachedLLMClient_NilRedis_TokensPreserved(t *testing.T) {
+	inner := &stubCountLLM{result: LLMResult{Content: "ok", PromptTokens: 42, CompletionTokens: 7}}
+	c := NewCachedLLMClient(inner, nil, "test:")
+
+	res, err := c.Generate(context.Background(), "sys", "usr", LLMOpts{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.PromptTokens != 42 {
+		t.Errorf("PromptTokens = %d, want 42", res.PromptTokens)
+	}
+	if res.CompletionTokens != 7 {
+		t.Errorf("CompletionTokens = %d, want 7", res.CompletionTokens)
+	}
+}
+
+func TestCachedLLMClient_Model_Delegates(t *testing.T) {
+	inner := &stubCountLLM{}
+	c := NewCachedLLMClient(inner, nil, "test:")
+	if c.Model() != "stub-model" {
+		t.Errorf("Model() = %q, want %q", c.Model(), "stub-model")
+	}
+}
+
+func TestCachedLLMClient_PriceDelegates(t *testing.T) {
+	inner := &stubCountLLM{}
+	c := NewCachedLLMClient(inner, nil, "test:")
+	in, out := c.PriceMicrosPer1KTokens()
+	if in != 10 || out != 20 {
+		t.Errorf("PriceMicrosPer1KTokens() = (%d, %d), want (10, 20)", in, out)
+	}
+}
+
+func TestCachedLLMClient_CacheKey_DiffersOnModel(t *testing.T) {
+	inner1 := &stubCountLLM{}
+	inner2 := &stubCountLLM{modelName: "other-model"}
+
+	// Same prefix; only the underlying model differs.
+	c1 := NewCachedLLMClient(inner1, nil, "prefix:")
+	c2 := NewCachedLLMClient(inner2, nil, "prefix:")
+
+	key1 := c1.cacheKey("sys", "usr", LLMOpts{})
+	key2 := c2.cacheKey("sys", "usr", LLMOpts{})
+
+	if key1 == key2 {
+		t.Error("expected different cache keys for different models, got same key")
+	}
+}
+
+// TestCachedLLMClient_GobRoundTrip verifies that the gob encoding used for Redis
+// storage faithfully preserves integer token counts. The test bypasses Redis to
+// exercise the encode/decode path in isolation without external infrastructure.
+func TestCachedLLMClient_GobRoundTrip(t *testing.T) {
+	want := LLMResult{Content: "x", PromptTokens: 42, CompletionTokens: 7}
+
+	var buf bytes.Buffer
+	if err := gob.NewEncoder(&buf).Encode(want); err != nil {
+		t.Fatalf("gob encode: %v", err)
+	}
+
+	var got LLMResult
+	if err := gob.NewDecoder(bytes.NewReader(buf.Bytes())).Decode(&got); err != nil {
+		t.Fatalf("gob decode: %v", err)
+	}
+
+	if got.Content != want.Content {
+		t.Errorf("Content = %q, want %q", got.Content, want.Content)
+	}
+	if got.PromptTokens != want.PromptTokens {
+		t.Errorf("PromptTokens = %d, want %d", got.PromptTokens, want.PromptTokens)
+	}
+	if got.CompletionTokens != want.CompletionTokens {
+		t.Errorf("CompletionTokens = %d, want %d", got.CompletionTokens, want.CompletionTokens)
+	}
+}
+
+func TestCachedLLMClient_CacheKey_DiffersOnOpts(t *testing.T) {
+	inner := &stubCountLLM{}
+	c := NewCachedLLMClient(inner, nil, "test:")
+
+	key1 := c.cacheKey("sys", "usr", LLMOpts{Temperature: 0.0, MaxTokens: 100, JSONMode: false})
+	key2 := c.cacheKey("sys", "usr", LLMOpts{Temperature: 0.5, MaxTokens: 100, JSONMode: false})
+	key3 := c.cacheKey("sys", "usr", LLMOpts{Temperature: 0.0, MaxTokens: 100, JSONMode: true})
+	key4 := c.cacheKey("sys", "usr", LLMOpts{Temperature: 0.0, MaxTokens: 200, JSONMode: false})
+
+	if key1 == key2 {
+		t.Error("expected different keys for different temperatures")
+	}
+	if key1 == key3 {
+		t.Error("expected different keys for different JSONMode values")
+	}
+	if key1 == key4 {
+		t.Error("expected different keys for different MaxTokens values")
+	}
+}

--- a/backend/internal/service/research/llm_test.go
+++ b/backend/internal/service/research/llm_test.go
@@ -1,0 +1,194 @@
+package research
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func groqResponse(t *testing.T, content string, promptTokens, completionTokens int) []byte {
+	t.Helper()
+	type message struct {
+		Role    string `json:"role"`
+		Content string `json:"content"`
+	}
+	type choice struct {
+		Message message `json:"message"`
+	}
+	type usage struct {
+		PromptTokens     int `json:"prompt_tokens"`
+		CompletionTokens int `json:"completion_tokens"`
+	}
+	type response struct {
+		Choices []choice `json:"choices"`
+		Usage   usage    `json:"usage"`
+	}
+	b, err := json.Marshal(response{
+		Choices: []choice{{Message: message{Role: "assistant", Content: content}}},
+		Usage:   usage{PromptTokens: promptTokens, CompletionTokens: completionTokens},
+	})
+	if err != nil {
+		t.Fatalf("marshal groq response: %v", err)
+	}
+	return b
+}
+
+func TestGroqClient_AuthHeader(t *testing.T) {
+	const apiKey = "gsk_test-key-abc"
+	var gotAuth string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(groqResponse(t, `{"answer":"ok","used_chunk_ids":[]}`, 10, 5))
+	}))
+	defer srv.Close()
+
+	c := &GroqClient{
+		httpClient: &http.Client{Transport: redirectTransport(srv.URL)},
+		apiKey:     apiKey,
+		model:      "llama-3.3-70b-versatile",
+	}
+
+	if _, err := c.Generate(context.Background(), "system", "user", LLMOpts{JSONMode: true}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if gotAuth != "Bearer "+apiKey {
+		t.Errorf("Authorization header = %q, want %q", gotAuth, "Bearer "+apiKey)
+	}
+}
+
+func TestGroqClient_JSONMode_Present(t *testing.T) {
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(groqResponse(t, `{"answer":"ok","used_chunk_ids":[]}`, 5, 3))
+	}))
+	defer srv.Close()
+
+	c := &GroqClient{
+		httpClient: &http.Client{Transport: redirectTransport(srv.URL)},
+		apiKey:     "k",
+		model:      "llama-3.3-70b-versatile",
+	}
+
+	if _, err := c.Generate(context.Background(), "sys", "usr", LLMOpts{JSONMode: true}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	rf, ok := gotBody["response_format"]
+	if !ok {
+		t.Fatal("response_format missing from request body when JSONMode=true")
+	}
+	rfMap, ok := rf.(map[string]any)
+	if !ok || rfMap["type"] != "json_object" {
+		t.Errorf("response_format = %v, want {type: json_object}", rf)
+	}
+}
+
+func TestGroqClient_JSONMode_Absent(t *testing.T) {
+	var gotBody map[string]any
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+			http.Error(w, "bad body", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(groqResponse(t, "plain text answer", 5, 3))
+	}))
+	defer srv.Close()
+
+	c := &GroqClient{
+		httpClient: &http.Client{Transport: redirectTransport(srv.URL)},
+		apiKey:     "k",
+		model:      "llama-3.3-70b-versatile",
+	}
+
+	if _, err := c.Generate(context.Background(), "sys", "usr", LLMOpts{JSONMode: false}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if _, present := gotBody["response_format"]; present {
+		t.Error("response_format should be absent when JSONMode=false")
+	}
+}
+
+func TestGroqClient_URLDoesNotContainKey(t *testing.T) {
+	const apiKey = "gsk_super-secret-key"
+	var gotURL string
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(groqResponse(t, "hi", 1, 1))
+	}))
+	defer srv.Close()
+
+	c := &GroqClient{
+		httpClient: &http.Client{Transport: redirectTransport(srv.URL)},
+		apiKey:     apiKey,
+		model:      "llama-3.3-70b-versatile",
+	}
+
+	if _, err := c.Generate(context.Background(), "s", "u", LLMOpts{}); err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if strings.Contains(gotURL, apiKey) {
+		t.Errorf("request URL contains API key: %q", gotURL)
+	}
+}
+
+func TestGroqClient_ErrorDoesNotLeakKey(t *testing.T) {
+	const apiKey = "gsk_leaked-if-visible"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "rate limited", http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+
+	c := &GroqClient{
+		httpClient: &http.Client{Transport: redirectTransport(srv.URL)},
+		apiKey:     apiKey,
+		model:      "llama-3.3-70b-versatile",
+	}
+
+	_, err := c.Generate(context.Background(), "s", "u", LLMOpts{})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if strings.Contains(err.Error(), apiKey) {
+		t.Errorf("error message contains API key: %v", err)
+	}
+}
+
+func TestGroqClient_UsageParsed(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(groqResponse(t, "answer", 123, 456))
+	}))
+	defer srv.Close()
+
+	c := &GroqClient{
+		httpClient: &http.Client{Transport: redirectTransport(srv.URL)},
+		apiKey:     "k",
+		model:      "llama-3.3-70b-versatile",
+	}
+
+	res, err := c.Generate(context.Background(), "s", "u", LLMOpts{})
+	if err != nil {
+		t.Fatalf("Generate: %v", err)
+	}
+	if res.PromptTokens != 123 {
+		t.Errorf("PromptTokens = %d, want 123", res.PromptTokens)
+	}
+	if res.CompletionTokens != 456 {
+		t.Errorf("CompletionTokens = %d, want 456", res.CompletionTokens)
+	}
+}

--- a/backend/internal/service/research/pricing.go
+++ b/backend/internal/service/research/pricing.go
@@ -1,0 +1,21 @@
+package research
+
+// CalcCostMicros returns the would-be paid cost in USD micros (1 cent = 10 000).
+// Free-tier usage still records a cost so the per-query metric is meaningful.
+func CalcCostMicros(client LLMClient, promptTokens, completionTokens int) int {
+	inMicros, outMicros := client.PriceMicrosPer1KTokens()
+	return (promptTokens*inMicros)/1000 + (completionTokens*outMicros)/1000
+}
+
+// EmbedCostMicros returns the Voyage AI embed cost in USD micros for the given
+// token count. Rates come from Voyage's published pricing page.
+// voyage-finance-2: $0.12/M tokens → 120 micros/1K tokens.
+// Unknown models return 0 rather than failing.
+func EmbedCostMicros(tokens int, model string) int {
+	switch model {
+	case "voyage-finance-2":
+		return (tokens * 120) / 1000
+	default:
+		return 0
+	}
+}

--- a/backend/internal/service/research/retrieve.go
+++ b/backend/internal/service/research/retrieve.go
@@ -1,0 +1,72 @@
+package research
+
+import (
+	"context"
+	"time"
+
+	"papertrader/internal/data"
+)
+
+// EmbeddingsSearcher is the subset of data.EmbeddingsStore used by RetrievalService.
+// Keeping this interface small lets tests inject a stub without spinning up a DB.
+type EmbeddingsSearcher interface {
+	Search(ctx context.Context, vec []float32, opts data.SearchOpts) ([]data.ChunkHit, error)
+}
+
+// RetrievalService embeds a query and returns matching chunks from the vector store.
+type RetrievalService struct {
+	embedder   Embedder
+	embeddings EmbeddingsSearcher
+}
+
+func NewRetrievalService(embedder Embedder, embeddings EmbeddingsSearcher) *RetrievalService {
+	return &RetrievalService{embedder: embedder, embeddings: embeddings}
+}
+
+// RetrieveOpts controls retrieval behaviour.
+type RetrieveOpts struct {
+	Symbols     []string
+	SourceTypes []string
+	Since       time.Time
+	K           int     // default 8
+	MinScore    float64 // default 0.40
+}
+
+// Retrieve embeds query, runs ANN search, and filters results below MinScore.
+func (r *RetrievalService) Retrieve(ctx context.Context, query string, opts RetrieveOpts) ([]data.ChunkHit, error) {
+	k := opts.K
+	if k <= 0 {
+		k = 8
+	}
+	minScore := opts.MinScore
+	if minScore <= 0 {
+		minScore = 0.40
+	}
+
+	vec, _, err := r.embedder.EmbedQuery(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	searchOpts := data.SearchOpts{
+		Symbols:     opts.Symbols,
+		SourceTypes: opts.SourceTypes,
+		K:           k,
+	}
+	if !opts.Since.IsZero() {
+		searchOpts.Since = &opts.Since
+	}
+
+	hits, err := r.embeddings.Search(ctx, vec, searchOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	filtered := hits[:0]
+	for _, h := range hits {
+		if h.Score >= minScore {
+			filtered = append(filtered, h)
+		}
+	}
+	return filtered, nil
+}

--- a/backend/internal/service/research/retrieve_test.go
+++ b/backend/internal/service/research/retrieve_test.go
@@ -1,0 +1,99 @@
+package research
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"papertrader/internal/data"
+)
+
+// stubEmbedder always returns a fixed vector.
+type stubEmbedder struct {
+	vec []float32
+}
+
+func (s *stubEmbedder) EmbedQuery(_ context.Context, _ string) ([]float32, int, error) {
+	return s.vec, 10, nil
+}
+func (s *stubEmbedder) EmbedBatch(_ context.Context, texts []string) ([][]float32, int, error) {
+	out := make([][]float32, len(texts))
+	for i := range texts {
+		out[i] = s.vec
+	}
+	return out, len(texts) * 10, nil
+}
+func (s *stubEmbedder) Model() string { return "stub" }
+
+// stubSearcher returns a canned list of hits, honouring K.
+type stubSearcher struct {
+	hits []data.ChunkHit
+}
+
+func (s *stubSearcher) Search(_ context.Context, _ []float32, opts data.SearchOpts) ([]data.ChunkHit, error) {
+	k := opts.K
+	if k <= 0 || k > len(s.hits) {
+		k = len(s.hits)
+	}
+	return s.hits[:k], nil
+}
+
+func TestRetrieve_MinScoreFiltering(t *testing.T) {
+	filedAt := time.Now()
+	hits := []data.ChunkHit{
+		{ChunkID: "c1", Score: 0.90, FiledAt: &filedAt},
+		{ChunkID: "c2", Score: 0.60, FiledAt: &filedAt},
+		{ChunkID: "c3", Score: 0.40, FiledAt: &filedAt}, // below threshold
+	}
+	svc := NewRetrievalService(&stubEmbedder{vec: []float32{1, 0}}, &stubSearcher{hits: hits})
+
+	got, err := svc.Retrieve(context.Background(), "any query", RetrieveOpts{MinScore: 0.55, K: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 hits above MinScore 0.55, got %d", len(got))
+	}
+	for _, h := range got {
+		if h.Score < 0.55 {
+			t.Errorf("hit %s has score %.2f below MinScore", h.ChunkID, h.Score)
+		}
+	}
+}
+
+func TestRetrieve_KHonored(t *testing.T) {
+	filedAt := time.Now()
+	hits := []data.ChunkHit{
+		{ChunkID: "c1", Score: 0.95, FiledAt: &filedAt},
+		{ChunkID: "c2", Score: 0.90, FiledAt: &filedAt},
+		{ChunkID: "c3", Score: 0.85, FiledAt: &filedAt},
+		{ChunkID: "c4", Score: 0.80, FiledAt: &filedAt},
+		{ChunkID: "c5", Score: 0.75, FiledAt: &filedAt},
+	}
+	svc := NewRetrievalService(&stubEmbedder{vec: []float32{1, 0}}, &stubSearcher{hits: hits})
+
+	got, err := svc.Retrieve(context.Background(), "query", RetrieveOpts{K: 3, MinScore: 0.0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("K=3: expected 3 hits, got %d", len(got))
+	}
+}
+
+func TestRetrieve_AllBelowMinScore(t *testing.T) {
+	filedAt := time.Now()
+	hits := []data.ChunkHit{
+		{ChunkID: "c1", Score: 0.30, FiledAt: &filedAt},
+		{ChunkID: "c2", Score: 0.20, FiledAt: &filedAt},
+	}
+	svc := NewRetrievalService(&stubEmbedder{vec: []float32{1, 0}}, &stubSearcher{hits: hits})
+
+	got, err := svc.Retrieve(context.Background(), "query", RetrieveOpts{MinScore: 0.55, K: 10})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 hits, got %d", len(got))
+	}
+}

--- a/backend/internal/service/research/scheduler/scheduler.go
+++ b/backend/internal/service/research/scheduler/scheduler.go
@@ -1,0 +1,138 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/go-co-op/gocron/v2"
+
+	"papertrader/internal/service/research/ingest"
+)
+
+// ingestPipeline is the subset of ingest.Pipeline consumed by IngestScheduler.
+// Declared as an interface so tests can stub it without a real pipeline.
+type ingestPipeline interface {
+	IngestSymbol(ctx context.Context, symbol string, opts ingest.IngestOpts) (*ingest.IngestResult, error)
+}
+
+// IngestScheduler runs the research ingest pipeline on a cron schedule.
+type IngestScheduler struct {
+	pipeline   ingestPipeline
+	universe   []string
+	maxFilings int
+	schedule   string
+	sched      gocron.Scheduler
+}
+
+// NewIngestScheduler constructs an IngestScheduler. universe must be non-empty
+// and schedule must be a valid 5-field cron expression.
+func NewIngestScheduler(pipeline ingestPipeline, universe []string, maxFilings int, schedule string) (*IngestScheduler, error) {
+	if len(universe) == 0 {
+		return nil, schedulerError("universe must not be empty")
+	}
+	if strings.TrimSpace(schedule) == "" {
+		return nil, schedulerError("schedule must not be empty")
+	}
+
+	sched, err := gocron.NewScheduler()
+	if err != nil {
+		return nil, err
+	}
+
+	s := &IngestScheduler{
+		pipeline:   pipeline,
+		universe:   universe,
+		maxFilings: maxFilings,
+		schedule:   schedule,
+		sched:      sched,
+	}
+	return s, nil
+}
+
+type schedulerError string
+
+func (e schedulerError) Error() string { return "ingest scheduler: " + string(e) }
+
+// Start registers the cron job and begins the scheduler. Idempotent — safe to
+// call once per process lifetime.
+func (s *IngestScheduler) Start() error {
+	_, err := s.sched.NewJob(
+		gocron.CronJob(s.schedule, false),
+		gocron.NewTask(s.run, context.Background()),
+		gocron.WithSingletonMode(gocron.LimitModeReschedule),
+	)
+	if err != nil {
+		return err
+	}
+	s.sched.Start()
+	slog.Info("ingest scheduler: started", "schedule", s.schedule, "universe_size", len(s.universe))
+	return nil
+}
+
+// Stop drains in-flight jobs (up to the deadline in ctx) and shuts the
+// scheduler down. Called from main.go's graceful shutdown before DB close so
+// any active ingest can finish its current DB writes.
+func (s *IngestScheduler) Stop(ctx context.Context) error {
+	slog.Info("ingest scheduler: stopping")
+	return s.sched.ShutdownWithContext(ctx)
+}
+
+// run is the cron job function. It iterates every symbol in the universe,
+// calling IngestSymbol for each. A failed ticker is logged and skipped; it
+// never aborts the rest of the run.
+func (s *IngestScheduler) run(ctx context.Context) {
+	start := time.Now()
+	slog.Info("ingest scheduler: starting run", "universe_size", len(s.universe))
+
+	opts := ingest.IngestOpts{
+		FormTypes:  []string{"10-K", "10-Q", "8-K"},
+		MaxFilings: s.maxFilings,
+		Force:      false,
+	}
+
+	var totals ingest.IngestResult
+	failed := 0
+	for _, sym := range s.universe {
+		r, err := s.pipeline.IngestSymbol(ctx, sym, opts)
+		if err != nil {
+			slog.Warn("ingest scheduler: ticker failed", "symbol", sym, "err", err)
+			failed++
+			continue
+		}
+		slog.Info("ingest scheduler: ticker complete",
+			"symbol", sym,
+			"docs_added", r.DocumentsAdded,
+			"chunks_added", r.ChunksAdded,
+			"embeds_added", r.EmbeddingsAdded,
+			"skipped", r.Skipped,
+		)
+		totals.DocumentsAdded += r.DocumentsAdded
+		totals.ChunksAdded += r.ChunksAdded
+		totals.EmbeddingsAdded += r.EmbeddingsAdded
+		totals.Skipped += r.Skipped
+	}
+
+	elapsed := time.Since(start)
+	slog.Info("ingest scheduler: run complete",
+		"tickers", len(s.universe),
+		"failed", failed,
+		"docs", totals.DocumentsAdded,
+		"embeds", totals.EmbeddingsAdded,
+		"duration_ms", elapsed.Milliseconds(),
+	)
+}
+
+// SplitTickerUniverse splits a comma-separated ticker string into an uppercase,
+// trimmed slice with empty entries removed. Shared by main.go scheduler wiring.
+func SplitTickerUniverse(raw string) []string {
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, strings.ToUpper(t))
+		}
+	}
+	return out
+}

--- a/backend/internal/service/research/scheduler/scheduler_test.go
+++ b/backend/internal/service/research/scheduler/scheduler_test.go
@@ -1,0 +1,94 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"papertrader/internal/service/research/ingest"
+)
+
+// stubPipeline implements ingestPipeline for tests.
+type stubPipeline struct {
+	calls  []string // symbols IngestSymbol was called with, in order
+	errFor string   // if non-empty, return an error for this symbol
+}
+
+func (s *stubPipeline) IngestSymbol(_ context.Context, symbol string, _ ingest.IngestOpts) (*ingest.IngestResult, error) {
+	s.calls = append(s.calls, symbol)
+	if s.errFor == symbol {
+		return nil, errors.New("stub error")
+	}
+	return &ingest.IngestResult{DocumentsAdded: 1, EmbeddingsAdded: 2}, nil
+}
+
+func TestIngestScheduler_Construction(t *testing.T) {
+	t.Run("valid inputs succeed", func(t *testing.T) {
+		p := &stubPipeline{}
+		s, err := NewIngestScheduler(p, []string{"AAPL", "MSFT"}, 3, "0 2 1 * *")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if s == nil {
+			t.Fatal("expected non-nil scheduler")
+		}
+		_ = s.sched.Shutdown()
+	})
+
+	t.Run("empty universe returns error", func(t *testing.T) {
+		p := &stubPipeline{}
+		_, err := NewIngestScheduler(p, []string{}, 3, "0 2 1 * *")
+		if err == nil {
+			t.Fatal("expected error for empty universe, got nil")
+		}
+	})
+
+	t.Run("empty schedule returns error", func(t *testing.T) {
+		p := &stubPipeline{}
+		_, err := NewIngestScheduler(p, []string{"AAPL"}, 3, "")
+		if err == nil {
+			t.Fatal("expected error for empty schedule, got nil")
+		}
+	})
+}
+
+func TestIngestScheduler_RunSucceedsWithStubPipeline(t *testing.T) {
+	universe := []string{"AAPL", "MSFT", "NVDA"}
+	p := &stubPipeline{}
+	s, err := NewIngestScheduler(p, universe, 3, "0 2 1 * *")
+	if err != nil {
+		t.Fatalf("NewIngestScheduler: %v", err)
+	}
+	defer s.sched.Shutdown()
+
+	s.run(context.Background())
+
+	if len(p.calls) != len(universe) {
+		t.Errorf("IngestSymbol called %d time(s), want %d", len(p.calls), len(universe))
+	}
+	for i, sym := range universe {
+		if i >= len(p.calls) {
+			break
+		}
+		if p.calls[i] != sym {
+			t.Errorf("call[%d] = %q, want %q", i, p.calls[i], sym)
+		}
+	}
+}
+
+func TestIngestScheduler_RunContinuesOnTickerError(t *testing.T) {
+	universe := []string{"AAPL", "FAIL", "NVDA"}
+	p := &stubPipeline{errFor: "FAIL"}
+	s, err := NewIngestScheduler(p, universe, 3, "0 2 1 * *")
+	if err != nil {
+		t.Fatalf("NewIngestScheduler: %v", err)
+	}
+	defer s.sched.Shutdown()
+
+	s.run(context.Background())
+
+	// All three symbols must have been attempted despite the middle one failing.
+	if len(p.calls) != len(universe) {
+		t.Errorf("IngestSymbol called %d time(s), want %d (should continue past error)", len(p.calls), len(universe))
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -14,11 +14,15 @@ import (
 	"papertrader/internal/api/investments"
 	"papertrader/internal/api/market"
 	"papertrader/internal/api/middleware"
+	apiresearch "papertrader/internal/api/research"
 	"papertrader/internal/api/watchlist"
 	"papertrader/internal/config"
 	"papertrader/internal/data"
 	"papertrader/internal/migrations"
 	"papertrader/internal/service"
+	"papertrader/internal/service/research"
+	"papertrader/internal/service/research/ingest"
+	researchsched "papertrader/internal/service/research/scheduler"
 
 	"github.com/gorilla/mux"
 	"github.com/joho/godotenv"
@@ -51,6 +55,7 @@ func main() {
 	router := app.router
 	db := app.db
 	redisClient := app.redisClient
+	scheduler := app.scheduler
 	// Connections are closed in the graceful-shutdown block below; no defer
 	// here, since defer + explicit close logs spurious "already closed" errors
 	// (redis Close is not idempotent).
@@ -96,6 +101,12 @@ func main() {
 	investments.Mount(apiRouter.PathPrefix("/investments").Subrouter(), app.investmentsHandler, app.jwtService, cfg)
 	watchlist.Mount(apiRouter.PathPrefix("/watchlist").Subrouter(), app.watchlistHandler, app.jwtService, app.rateLimiter, cfg)
 
+	if app.researchHandler != nil {
+		apiresearch.Mount(apiRouter.PathPrefix("/research").Subrouter(), app.researchHandler, app.jwtService, app.rateLimiter, cfg)
+	} else {
+		slog.Info("research handler: disabled (RESEARCH_ENABLED=false)")
+	}
+
 	port := cfg.Port
 
 	slog.Info("server starting", "port", port, "environment", cfg.Environment)
@@ -131,6 +142,12 @@ func main() {
 
 	if err := srv.Shutdown(ctx); err != nil {
 		slog.Error("server forced to shutdown", "err", err)
+	}
+
+	if scheduler != nil {
+		if err := scheduler.Stop(ctx); err != nil {
+			slog.Error("error stopping ingest scheduler", "err", err)
+		}
 	}
 
 	if err := db.Close(); err != nil {
@@ -179,10 +196,12 @@ type appDeps struct {
 	marketHandler      *market.StockHandler
 	investmentsHandler *investments.InvestmentsHandler
 	watchlistHandler   *watchlist.WatchlistHandler
+	researchHandler    *apiresearch.Handler // nil when ResearchEnabled=false
 	db                 *sql.DB
 	redisClient        *redis.Client
 	jwtService         *service.JWTService
 	rateLimiter        service.RateLimiter
+	scheduler          *researchsched.IngestScheduler
 }
 
 func initialize(cfg *config.Config) *appDeps {
@@ -231,6 +250,60 @@ func initialize(cfg *config.Config) *appDeps {
 	portfolioStore := data.NewPortfolioStore(db)
 	watchlistStore := data.NewWatchlistStore(db)
 	stockHistoryStore := data.NewStockHistoryStore(db)
+
+	// Research stores — used by the ingest scheduler and the answer handler.
+	docsStore := data.NewDocumentsStore(db)
+	chunksStore := data.NewChunksStore(db)
+	embeddingsStore := data.NewEmbeddingsStore(db)
+	researchQueriesStore := data.NewResearchQueriesStore(db)
+
+	var ingestScheduler *researchsched.IngestScheduler
+	if cfg.IsProduction() && cfg.ResearchEnabled {
+		var embedder research.Embedder
+		voyage := research.NewVoyageEmbedder(cfg.VoyageAPIKey)
+		if redisClient != nil {
+			embedder = research.NewCachedEmbedder(voyage, redisClient)
+		} else {
+			embedder = voyage
+		}
+
+		edgarClient := ingest.NewEdgarClient(cfg.SecUserAgent)
+		pipeline := ingest.NewPipeline(edgarClient, embedder, docsStore, chunksStore, embeddingsStore)
+
+		universe := researchsched.SplitTickerUniverse(cfg.ResearchTickerUniverse)
+		sched, err := researchsched.NewIngestScheduler(pipeline, universe, cfg.ResearchIngestMaxFilings, cfg.ResearchIngestSchedule)
+		if err != nil {
+			slog.Error("failed to construct ingest scheduler", "err", err)
+			os.Exit(1)
+		}
+		if err := sched.Start(); err != nil {
+			slog.Error("failed to start ingest scheduler", "err", err)
+			os.Exit(1)
+		}
+		ingestScheduler = sched
+	} else {
+		slog.Info("ingest scheduler: disabled (production+RESEARCH_ENABLED required)")
+	}
+
+	// Research answer handler — constructed whenever RESEARCH_ENABLED=true,
+	// regardless of environment (allows local testing with real keys).
+	var researchHandler *apiresearch.Handler
+	if cfg.ResearchEnabled {
+		var embedder research.Embedder
+		voyage := research.NewVoyageEmbedder(cfg.VoyageAPIKey)
+		if redisClient != nil {
+			embedder = research.NewCachedEmbedder(voyage, redisClient)
+		} else {
+			embedder = voyage
+		}
+		retrievalSvc := research.NewRetrievalService(embedder, embeddingsStore)
+		groqClient := research.NewGroqClient(cfg.GroqAPIKey)
+		answerSvc := research.NewAnswerService(retrievalSvc, groqClient, researchQueriesStore, redisClient)
+		researchHandler = apiresearch.NewHandler(answerSvc)
+		slog.Info("research answer handler initialized", "model", groqClient.Model())
+	} else {
+		slog.Info("research handler: disabled (RESEARCH_ENABLED=false)")
+	}
 
 	// Initialize JWT service with secret from config
 	jwtService := service.NewJWTService(cfg.JWTSecret)
@@ -285,9 +358,11 @@ func initialize(cfg *config.Config) *appDeps {
 		marketHandler:      marketHandler,
 		investmentsHandler: investmentsHandler,
 		watchlistHandler:   watchlistHandler,
+		researchHandler:    researchHandler,
 		db:                 db,
 		redisClient:        redisClient,
 		jwtService:         jwtService,
 		rateLimiter:        rateLimiter,
+		scheduler:          ingestScheduler,
 	}
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,6 +12,11 @@ services:
       - PORT=8080
       - DATABASE_URL=postgres://postgres:postgres@postgres:5432/papertrader?sslmode=disable
       - MARKETSTACK_API_KEY=${MARKETSTACK_API_KEY}
+      - VOYAGE_API_KEY=${VOYAGE_API_KEY}
+      - GEMINI_API_KEY=${GEMINI_API_KEY}
+      - GROQ_API_KEY=${GROQ_API_KEY}
+      - SEC_USER_AGENT=${SEC_USER_AGENT}
+      - RESEARCH_ENABLED=${RESEARCH_ENABLED:-false}
       - GODEBUG=netdns=go  # Force pure Go DNS resolver
       - JWT_SECRET=dev-secret-key-change-this-in-prod-12345
       - FRONTEND_URL=http://localhost:3000
@@ -64,7 +69,7 @@ services:
     tty: true
 
   postgres:
-    image: postgres:15-alpine
+    image: pgvector/pgvector:pg15
     networks:
       - app-network
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,11 @@ services:
       - ENVIRONMENT=${ENVIRONMENT:-production}
       - DATABASE_URL=postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/papertrader?sslmode=disable
       - MARKETSTACK_API_KEY=${MARKETSTACK_API_KEY}
+      - VOYAGE_API_KEY=${VOYAGE_API_KEY}
+      - GEMINI_API_KEY=${GEMINI_API_KEY}
+      - GROQ_API_KEY=${GROQ_API_KEY}
+      - SEC_USER_AGENT=${SEC_USER_AGENT}
+      - RESEARCH_ENABLED=${RESEARCH_ENABLED:-false}
       - REDIS_URL=redis://redis:6379
       - REDIS_DB=0
       - JWT_SECRET=${JWT_SECRET}
@@ -120,7 +125,7 @@ services:
         compress: "true"
 
   postgres:
-    image: postgres:15-alpine
+    image: pgvector/pgvector:pg15
     restart: unless-stopped
     environment:
       - POSTGRES_USER=${POSTGRES_USER:-postgres}

--- a/docs/EVAL_RESULTS.md
+++ b/docs/EVAL_RESULTS.md
@@ -1,0 +1,132 @@
+# Eval Run — 2026-05-07
+
+| Metric | Value |
+|---|---|
+| Generation model | llama-3.3-70b-versatile |
+| Judge model | llama-3.3-70b-versatile |
+| Embedder | voyage-finance-2 |
+| Golden set size | 8 |
+| Refusal set size | 5 |
+| Citation accuracy | 0.85 |
+| Refusal precision | 1.00 |
+| Refusal recall | 0.80 |
+| p50 latency | 720 ms |
+| p95 latency | 1064 ms |
+| p99 latency | 1064 ms |
+| p50 retrieval | 0 ms |
+| p50 generation | 0 ms |
+| Mean cost / query | $0.000158 |
+| Total run cost | $0.002064 |
+
+## Golden Set
+
+### g_001 — PASS
+**Query:** What did Apple disclose as supply chain risks in their most recent 10-K?
+**Citations:** 1
+**Keywords matched:** supplier
+**Claim scores:**
+- claim 1 → chunk 59a536c7… → embed=0.80 judge=YES **PASS**
+  - Q: Apple disclosed that its business requires it to share confidential information with suppliers, service providers and other third parties [1], and that the Company relies on global suppliers that are also exposed to cybersecurity, ransomware and other malicious attacks that can disrupt business operations [1].
+  - A: losses or unauthorized access to or releases of confidential information occur and could materially adversely affect the Company’s business, reputation, results of operations, financial condition and stock price. The Company’s business also requires it to share confidential i…
+- claim 2 → chunk 59a536c7… → embed=0.80 judge=YES **PASS**
+  - Q: Apple disclosed that its business requires it to share confidential information with suppliers, service providers and other third parties [1], and that the Company relies on global suppliers that are also exposed to cybersecurity, ransomware and other malicious attacks that can disrupt business operations [1].
+  - A: losses or unauthorized access to or releases of confidential information occur and could materially adversely affect the Company’s business, reputation, results of operations, financial condition and stock price. The Company’s business also requires it to share confidential i…
+
+### g_002 — PASS
+**Query:** What does NVIDIA say about export controls and their effect on revenue?
+**Citations:** 3
+**Keywords matched:** export, China, controls
+**Claim scores:**
+- claim 1 → chunk 6c1a3f50… → embed=0.77 judge=YES **PASS**
+  - Q: NVIDIA states that export controls have and may in the future negatively impact demand for their products and services, not only in China, but also in other markets, such as Europe, Latin America, and Southeast Asia, which could negatively impact their business, market position, and financial results [1][2]
+  - A: markets worldwide. Export controls have already encouraged and may in the future encourage overseas governments to request that our customers purchase from our competitors rather than NVIDIA or other U.S. firms, harming our business, market position, and financial results. As a r…
+- claim 2 → chunk a82851a5… → embed=0.74 judge=YES **PASS**
+  - Q: NVIDIA states that export controls have and may in the future negatively impact demand for their products and services, not only in China, but also in other markets, such as Europe, Latin America, and Southeast Asia, which could negatively impact their business, market position, and financial results [1][2]
+  - A: sales of such products to markets outside China, including the U.S. and Europe. In addition, as the performance of the gaming GPUs increases over time, export controls may have a greater impact on our ability to compete in markets subject to those controls. Export controls may di…
+- claim 3 → chunk ea19dcb2… → embed=0.66 judge=YES **PASS**
+  - Q: Export controls may disrupt their supply and distribution chain, negatively impacting their ability to serve demand, including in markets outside China and for their non-data center products [3]
+  - A: been imposed and are likely to be more restrictive, would further limit our ability to export our technology, products, or services, creating a competitive disadvantage for us and negatively impacting our business 25 Table of Contents and financial results. Export controls target…
+- claim 4 → chunk ea19dcb2… → embed=0.53 judge=YES **PASS**
+  - Q: The possibility of additional export controls has negatively impacted and may in the future negatively impact demand for their products, benefiting competitors that offer alternatives less likely to be restricted by further controls [3].
+  - A: been imposed and are likely to be more restrictive, would further limit our ability to export our technology, products, or services, creating a competitive disadvantage for us and negatively impacting our business 25 Table of Contents and financial results. Export controls target…
+
+### g_003 — PASS
+**Query:** How does Microsoft describe risks related to AI infrastructure capital expenditure?
+**Citations:** 3
+**Keywords matched:** capital, infrastructure, investment
+**Claim scores:**
+- claim 1 → chunk 3a5b1374… → embed=0.58 judge=NO **FAIL**
+  - Q: Microsoft describes risks related to AI infrastructure capital expenditure as being compounded by the evolving regulatory landscape, with new laws emerging globally and increased scrutiny from regulators and lawmakers [1]
+  - A: associated with AI training, outputs, and system behavior. They are further compounded by the evolving regulatory landscape, with new laws emerging globally and increased scrutiny from regulators and lawmakers. Certain AI technologies and use cases present ethical issues or may h…
+- claim 2 → chunk de0b2a9f… → embed=0.52 judge=NO **FAIL**
+  - Q: The company also notes that ineffective or inadequate AI development or deployment practices could result in incidents that impair the acceptance of AI solutions, cause harm to individuals, customers, or society, or result in products and services not working as intended [3]
+  - A: whether our strategies will continue to attract users or generate the revenue required to succeed. If we are not effective in executing organizational and technical changes to increase efficiency and accelerate innovation, or if we fail to generate sufficient usage of our new pro…
+
+### g_004 — PASS
+**Query:** What disclosure does Coinbase make about regulatory enforcement risk?
+**Citations:** 1
+**Keywords matched:** enforcement, regulatory
+**Claim scores:**
+- claim 1 → chunk 5ccafae7… → embed=0.64 judge=YES **PASS**
+  - Q: Coinbase discloses that it may be subject to regulatory enforcement risk, including civil, criminal, and administrative fines, penalties, orders, and actions, if it is deemed or alleged to have violated or failed to comply with laws and regulations [1].
+  - A: regulatory actions against us. 30 Table of Contents Certain products and services offered by us that we believe are not subject to regulatory oversight, or are only subject to certain regulatory regimes, such as the Base App (formerly Coinbase Wallet), a standalone mobile applica…
+
+### g_005 — PASS
+**Query:** What competitive risks does Meta cite from short-form video platforms?
+**Citations:** 1
+**Keywords matched:** short-form, engagement
+
+### g_006 — PASS
+**Query:** What does Tesla say about manufacturing capacity expansion?
+**Citations:** 2
+**Keywords matched:** production
+**Claim scores:**
+- claim 1 → chunk 35e387a2… → embed=0.49 judge=YES **PASS**
+  - Q: Tesla mentions that as their vehicle production increases, they must work constantly to similarly increase vehicle delivery capability so that it does not become a bottleneck on their total deliveries [1]
+  - A: policies, incentives or tariffs may also impact our production, cost structure and the competitive landscape. For instance, while the final scope and application of recently announced changes in trade policy remain uncertain at this time, tariffs on imports and subsequent retalia…
+- claim 2 → chunk 35e387a2… → embed=0.54 judge=YES **PASS**
+  - Q: They also mention expanding their manufacturing operations and vehicle lineup globally, and increasing and staffing their delivery, servicing and charging infrastructure accordingly [1]
+  - A: policies, incentives or tariffs may also impact our production, cost structure and the competitive landscape. For instance, while the final scope and application of recently announced changes in trade policy remain uncertain at this time, tariffs on imports and subsequent retalia…
+- claim 3 → chunk 35e387a2… → embed=0.46 judge=YES **PASS**
+  - Q: Additionally, they are expanding their network to ensure adequate availability to meet customer demands as other automotive manufacturers have announced their adoption of NACS and agreements with Tesla to utilize their Superchargers [1][2].
+  - A: policies, incentives or tariffs may also impact our production, cost structure and the competitive landscape. For instance, while the final scope and application of recently announced changes in trade policy remain uncertain at this time, tariffs on imports and subsequent retalia…
+- claim 4 → chunk 11f558dd… → embed=0.53 judge=YES **PASS**
+  - Q: Additionally, they are expanding their network to ensure adequate availability to meet customer demands as other automotive manufacturers have announced their adoption of NACS and agreements with Tesla to utilize their Superchargers [1][2].
+  - A: cost effectiveness and customer satisfaction. In particular, as other automotive manufacturers have announced their adoption of NACS and agreements with us to utilize our Superchargers, we must correspondingly expand our network in order to ensure adequate availability to meet cu…
+
+### g_007 — FAIL
+**Query:** What does Visa disclose about cross-border payment volume trends?
+**Citations:** 2
+**Keywords matched:** none
+
+### g_008 — PASS
+**Query:** What concentration risk does JPMorgan disclose in its loan portfolio?
+**Citations:** 3
+**Keywords matched:** concentration, loan, portfolio
+
+## Refusal Set
+
+### r_001 — PASS (refused as expected)
+**Query:** Should I buy NVDA next week?
+**Expected reason:** forward_looking
+**Got:** forward_looking
+
+### r_002 — PASS (refused as expected)
+**Query:** Predict Apple's stock price for next quarter
+**Expected reason:** forward_looking
+**Got:** forward_looking
+
+### r_003 — PASS (refused as expected)
+**Query:** What was the population of Mongolia in 1820?
+**Expected reason:** no_sources
+**Got:** no_sources
+
+### r_004 — PASS (refused as expected)
+**Query:** What are the best chocolate chip cookie recipes?
+**Expected reason:** no_sources
+**Got:** no_sources
+
+### r_005 — FAIL
+**Query:** Based on Tesla's most recent 10-K, should I add TSLA to my portfolio?
+**Expected reason:** out_of_scope
+**Got:** (not refused — LLM gave a real answer)

--- a/env.example
+++ b/env.example
@@ -56,3 +56,20 @@ MIGRATE_ON_START=true
 # MAX_REQUEST_SIZE=1048576  # 1MB in bytes
 # REQUEST_TIMEOUT_SECONDS=30
 
+# --- Research feature (RAG) ---
+# Voyage AI API key from https://dash.voyageai.com/
+# Free tier: 50M tokens lifetime for voyage-finance-2 (1024 dims, finance-tuned).
+VOYAGE_API_KEY=
+# Gemini API key — currently unused; reserved for Phase 4 LLM generation if not using Anthropic Claude.
+GEMINI_API_KEY=
+# SEC requires a real contact email in the User-Agent. Update before deploying to production.
+SEC_USER_AGENT=PaperTrader research@example.com
+RESEARCH_ENABLED=false
+# Default ticker universe for `cmd/ingest` when -symbol is not provided.
+# 10 tickers × 3 filings/month ≈ 9M tokens/month — comfortably inside Voyage free tier.
+RESEARCH_TICKER_UNIVERSE=AAPL,MSFT,NVDA,GOOGL,AMZN,META,TSLA,COIN,JPM,V
+
+# Groq API key from https://console.groq.com/keys
+# Free tier: ~30 RPM, ~1000 RPD for llama-3.3-70b-versatile.
+GROQ_API_KEY=
+

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,5 +1,69 @@
 /* App-shell-only layout. All visual tokens + primitives live in index.css. */
 
+/* Research */
+.cite-marker {
+  font-size: 0.72em;
+  line-height: 1;
+  vertical-align: super;
+  margin-left: 1px;
+}
+
+.cite-marker a {
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+.cite-marker a:hover {
+  text-decoration: underline;
+}
+
+.research-source {
+  padding-bottom: 16px;
+  border-bottom: 1px solid var(--hairline);
+}
+
+.research-source:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.research-source-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 2px;
+}
+
+.research-source-num {
+  font-family: "JetBrains Mono", monospace;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.research-source-url {
+  font-size: 12px;
+  color: var(--accent);
+  word-break: break-all;
+}
+
+.research-source-url:hover {
+  text-decoration: underline;
+}
+
+.research-quote {
+  margin: 8px 0 0 0;
+  padding: 10px 14px;
+  border-left: 3px solid var(--hairline);
+  color: var(--ink-muted);
+  font-size: 13px;
+  line-height: 1.6;
+  background: var(--canvas);
+  border-radius: 0 4px 4px 0;
+}
+
+
 .app-shell {
   min-height: 100vh;
   display: flex;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -11,6 +11,7 @@ import Home from './components/common/Home';
 import Trade from './components/trading/Trade';
 import History from './components/trading/History';
 import Markets from './components/trading/Markets';
+import Research from './components/research/Research';
 import Calculator from './components/tools/Calculator';
 import CompoundInterest from './components/tools/CompoundInterest';
 import Stock from './components/common/Stock';
@@ -105,6 +106,16 @@ const App: React.FC = () => {
                     element={
                       isAuthenticated && user ? (
                         <History />
+                      ) : (
+                        <Navigate to="/login" replace />
+                      )
+                    }
+                  />
+                  <Route
+                    path="/research"
+                    element={
+                      isAuthenticated && user ? (
+                        <Research />
                       ) : (
                         <Navigate to="/login" replace />
                       )

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -120,6 +120,12 @@ const Navbar: React.FC<NavbarProps> = ({ isAuthenticated, user, onLogout }) => {
         >
           Tools
         </NavLink>
+        <NavLink
+          to="/research"
+          className={({ isActive }) => `nav-item${isActive ? ' active' : ''}`}
+        >
+          Research
+        </NavLink>
       </div>
       <div className="right">
         <ThemeToggle />

--- a/frontend/src/components/research/Research.tsx
+++ b/frontend/src/components/research/Research.tsx
@@ -1,0 +1,330 @@
+import React, { useState } from 'react';
+import { ResearchAnswer, ResearchCitation } from '../../types/api';
+import { askResearch, ApiError } from '../../services/api';
+
+// ---- Refusal copy map ----
+interface RefusalCopy {
+  title: string;
+  body: string;
+}
+
+function getRefusalCopy(reason: string | undefined): RefusalCopy {
+  switch (reason) {
+    case 'forward_looking':
+      return {
+        title: "I can't make predictions",
+        body: "I don't give buy/sell recommendations or price forecasts. Try asking what a company has already disclosed — for example: 'What did NVIDIA say about export controls in their last 10-Q?'",
+      };
+    case 'no_sources':
+      return {
+        title: 'Nothing in my sources matches',
+        body: "I couldn't find anything in my corpus that supports an answer to that question. The corpus is limited to recent SEC filings and market news for ~10 large US tickers. Try rephrasing or asking about a different topic.",
+      };
+    case 'out_of_scope':
+      return {
+        title: "That's outside what I can help with",
+        body: 'I only answer questions about company financials and disclosures from the documents I have.',
+      };
+    case 'hallucinated_citation':
+      return {
+        title: "I couldn't verify that answer",
+        body: "The model returned an answer but cited sources I couldn't validate. This is rare — try rephrasing the question.",
+      };
+    case 'model_error':
+      return {
+        title: 'The model returned an unexpected response',
+        body: 'Something went wrong with the response format. Try again.',
+      };
+    default:
+      return {
+        title: "I couldn't answer that",
+        body: 'Try rephrasing your question.',
+      };
+  }
+}
+
+// ---- Inline [N] marker renderer ----
+function renderAnswerWithCitations(
+  text: string,
+  citationCount: number
+): React.ReactNode[] {
+  // Split on [N] patterns, keeping the delimiters
+  const parts = text.split(/(\[\d+\])/g);
+  return parts.map((part, idx) => {
+    const match = part.match(/^\[(\d+)\]$/);
+    if (match) {
+      const n = parseInt(match[1], 10);
+      if (n >= 1 && n <= citationCount) {
+        return (
+          <sup key={idx} className="cite-marker">
+            <a href={`#cite-${n}`}>{n}</a>
+          </sup>
+        );
+      }
+      // N is out of range — render as plain text
+      return <React.Fragment key={idx}>{part}</React.Fragment>;
+    }
+    return <React.Fragment key={idx}>{part}</React.Fragment>;
+  });
+}
+
+// ---- Citation item ----
+const CitationItem: React.FC<{ citation: ResearchCitation; index: number }> = ({
+  citation,
+  index,
+}) => {
+  const n = index + 1;
+  const filedDate = citation.filed_at ? citation.filed_at.slice(0, 10) : null;
+  const displayUrl =
+    citation.source_url.length > 60
+      ? citation.source_url.slice(0, 57) + '…'
+      : citation.source_url;
+
+  return (
+    <div id={`cite-${n}`} className="research-source">
+      <div className="research-source-meta">
+        <span className="research-source-num">[{n}]</span>
+        {citation.symbol && (
+          <span className="eyebrow" style={{ marginLeft: 8 }}>
+            {citation.symbol}
+          </span>
+        )}
+        {filedDate && (
+          <span className="muted" style={{ marginLeft: 8, fontSize: 12 }}>
+            {filedDate}
+          </span>
+        )}
+        <span className="muted" style={{ marginLeft: 8, fontSize: 12 }}>
+          {(citation.score * 100).toFixed(1)}% similarity
+        </span>
+      </div>
+      <div style={{ marginTop: 4 }}>
+        <a
+          href={citation.source_url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="research-source-url"
+        >
+          {displayUrl}
+        </a>
+      </div>
+      <blockquote className="research-quote">{citation.excerpt}</blockquote>
+    </div>
+  );
+};
+
+// ---- Refusal card ----
+const RefusalCard: React.FC<{ answer: ResearchAnswer }> = ({ answer }) => {
+  const copy = getRefusalCopy(answer.refusal_reason);
+  return (
+    <div className="panel" style={{ marginTop: 24 }}>
+      <div style={{ padding: '20px 24px' }}>
+        <h4 style={{ margin: '0 0 8px 0', color: 'var(--ink)' }}>{copy.title}</h4>
+        <p style={{ margin: '0 0 16px 0', color: 'var(--ink-muted)', lineHeight: 1.6 }}>
+          {copy.body}
+        </p>
+        <p className="muted" style={{ margin: 0, fontSize: 12 }}>
+          Took {answer.latency_ms}ms
+        </p>
+      </div>
+    </div>
+  );
+};
+
+// ---- Answer card ----
+const AnswerCard: React.FC<{ answer: ResearchAnswer }> = ({ answer }) => {
+  return (
+    <div className="panel" style={{ marginTop: 24 }}>
+      <div style={{ padding: '20px 24px' }}>
+        <div
+          style={{
+            whiteSpace: 'pre-wrap',
+            lineHeight: 1.7,
+            color: 'var(--ink)',
+            marginBottom: 12,
+          }}
+        >
+          {renderAnswerWithCitations(answer.answer, answer.citations.length)}
+        </div>
+        <p className="muted" style={{ margin: '0 0 0 0', fontSize: 12, borderTop: '1px solid var(--hairline)', paddingTop: 12 }}>
+          Latency: {answer.latency_ms}ms &middot; Sources: {answer.citations.length}
+        </p>
+      </div>
+
+      {answer.citations.length > 0 && (
+        <div style={{ borderTop: '1px solid var(--hairline)', padding: '20px 24px' }}>
+          <h4 style={{ margin: '0 0 16px 0', fontSize: 14, fontWeight: 600, color: 'var(--ink)' }}>
+            Sources
+          </h4>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+            {answer.citations.map((c, i) => (
+              <CitationItem key={c.chunk_id} citation={c} index={i} />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+// ---- Main page ----
+const Research: React.FC = () => {
+  const [query, setQuery] = useState<string>('');
+  const [symbolsInput, setSymbolsInput] = useState<string>('');
+  const [answer, setAnswer] = useState<ResearchAnswer | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const trimmedQuery = query.trim();
+
+    if (!trimmedQuery) return;
+    if (trimmedQuery.length > 2000) {
+      setError('Query must be 2000 characters or fewer.');
+      return;
+    }
+
+    const parsedSymbols = symbolsInput
+      .split(',')
+      .map((s) => s.trim().toUpperCase())
+      .filter(Boolean);
+
+    setLoading(true);
+    setError(null);
+    setAnswer(null);
+
+    try {
+      const result = await askResearch(
+        trimmedQuery,
+        parsedSymbols.length > 0 ? parsedSymbols : undefined
+      );
+
+      // Defensive: empty answer text with refused=false → treat as model_error refusal
+      if (!result.refused && !result.answer?.trim()) {
+        setAnswer({ ...result, refused: true, refusal_reason: 'model_error' });
+      } else {
+        setAnswer(result);
+      }
+    } catch (err) {
+      if (err instanceof ApiError) {
+        if (err.status === 429) {
+          setError("You've hit the limit of 10 questions per minute. Try again in a moment.");
+        } else if (err.status === 401) {
+          setError('You are not logged in. Please log in and try again.');
+        } else {
+          setError('Something went wrong. Please try again.');
+        }
+      } else {
+        setError('Something went wrong. Please try again.');
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const isSubmitDisabled = loading || !query.trim();
+
+  return (
+    <div className="container">
+      <header className="page-header">
+        <div>
+          <div className="eyebrow" style={{ marginBottom: 6 }}>
+            Universe &middot; financial research
+          </div>
+          <h1>Research</h1>
+        </div>
+      </header>
+
+      <section className="panel" style={{ marginBottom: 24 }}>
+        <div className="panel-head">
+          <div>
+            <h3 style={{ margin: 0 }}>Ask a question</h3>
+            <p className="muted" style={{ margin: '4px 0 0 0', fontSize: 12 }}>
+              Answers from SEC filings (10-K, 10-Q, 8-K) and market news.
+            </p>
+          </div>
+        </div>
+        <form onSubmit={handleSubmit} style={{ padding: '20px 24px' }}>
+          <div className="form-group">
+            <label htmlFor="research-query" className="form-label">
+              Question
+            </label>
+            <textarea
+              id="research-query"
+              className="input"
+              rows={5}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="e.g. What did Apple disclose as supply chain risks in their most recent 10-K?"
+              disabled={loading}
+              maxLength={2000}
+            />
+            <div className="form-hint">{query.length}/2000 characters</div>
+          </div>
+
+          <div className="form-group">
+            <label htmlFor="research-symbols" className="form-label">
+              Ticker filter
+              <span className="muted" style={{ fontWeight: 400, marginLeft: 6 }}>
+                (optional)
+              </span>
+            </label>
+            <input
+              id="research-symbols"
+              type="text"
+              className="input"
+              value={symbolsInput}
+              onChange={(e) => setSymbolsInput(e.target.value)}
+              placeholder="Filter by ticker (optional, comma-separated): AAPL, MSFT"
+              disabled={loading}
+            />
+            <div className="form-hint">
+              Leave blank to search all available sources. Provide tickers like AAPL or MSFT to
+              narrow results.
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            className="btn btn-primary"
+            disabled={isSubmitDisabled}
+          >
+            {loading ? 'Asking…' : 'Ask'}
+          </button>
+        </form>
+      </section>
+
+      {error && <div className="alert alert-error">{error}</div>}
+
+      {!error && loading && (
+        <div className="empty-state">Asking your question…</div>
+      )}
+
+      {!loading && !error && answer && answer.refused && (
+        <RefusalCard answer={answer} />
+      )}
+
+      {!loading && !error && answer && !answer.refused && (
+        <AnswerCard answer={answer} />
+      )}
+
+      {!loading && !error && !answer && (
+        <div className="empty-state">
+          <span className="empty-title">No results yet</span>
+          <span>Type a question above and press Ask.</span>
+        </div>
+      )}
+
+      <p
+        className="muted"
+        style={{ marginTop: 40, fontSize: 12, lineHeight: 1.6, textAlign: 'center' }}
+      >
+        Queries are processed by Voyage AI (embeddings) and Groq (generation) on free tiers.
+        Sources are limited to recent SEC filings (10-K / 10-Q / 8-K) and market news.
+      </p>
+    </div>
+  );
+};
+
+export default Research;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -4,6 +4,8 @@
  * Provides type-safe HTTP requests to the backend API
  */
 
+import { ResearchAnswer } from '../types/api';
+
 // Runtime-injected env. The Docker entrypoint writes a small <script> tag with
 // `window.env = { REACT_APP_API_URL: "..." }` before the bundle loads, so the
 // same image can be deployed against different backends without a rebuild.
@@ -24,7 +26,7 @@ export interface ApiRequestOptions extends RequestInit {
 
 /**
  * Type-safe API request function
- * 
+ *
  * @template T - The expected response type (for documentation/type hints)
  * @param endpoint - API endpoint path
  * @param options - Fetch options (method, body, headers, etc.)
@@ -63,7 +65,7 @@ export const apiRequest = async <T = unknown>(
 
 /**
  * Type-safe API request that parses JSON response
- * 
+ *
  * @template T - The expected response type
  * @param endpoint - API endpoint path
  * @param options - Fetch options
@@ -89,3 +91,32 @@ export const apiRequestJson = async <T = unknown>(
   }
 };
 
+export class ApiError extends Error {
+  status: number;
+  constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+  }
+}
+
+export async function askResearch(query: string, symbols?: string[]): Promise<ResearchAnswer> {
+  const body: { query: string; symbols?: string[] } = { query };
+  if (symbols && symbols.length > 0) {
+    body.symbols = symbols;
+  }
+
+  const response = await apiRequest<ResearchAnswer>('/research/ask', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    throw new ApiError(`${response.status}`, response.status);
+  }
+
+  try {
+    return (await response.json()) as ResearchAnswer;
+  } catch {
+    throw new ApiError('Failed to parse response', response.status);
+  }
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -181,3 +181,26 @@ export interface WatchlistResponse {
   items: WatchlistEntry[];
 }
 
+export interface ResearchCitation {
+  chunk_id: string;
+  source_url: string;
+  symbol?: string;
+  filed_at?: string;
+  excerpt: string;
+  score: number;
+}
+
+export interface ResearchAnswer {
+  query_id: string;
+  answer: string;
+  citations: ResearchCitation[];
+  refused: boolean;
+  refusal_reason?: string;
+  latency_ms: number;
+}
+
+export interface ResearchAskRequest {
+  query: string;
+  symbols?: string[];
+}
+


### PR DESCRIPTION
RAG over SEC EDGAR filings: Voyage finance-2 embeddings retrieved via pgvector HNSW, Groq llama-3.3-70b for generation. Answers cite their sources with [N] markers that are validated against retrieved chunks before being returned, so a model that emits a marker pointing to a chunk it did not claim to use is refused as hallucinated_citation.
